### PR TITLE
cel_interpretor: remove superfluous call to wazo-confd

### DIFF
--- a/integration_tests/suite/test_call_log_generation.py
+++ b/integration_tests/suite/test_call_log_generation.py
@@ -323,16 +323,22 @@ LINKEDID_END | 2015-06-18 14:09:02.272325 | SIP/as2mkq-0000001f | 1434650936.31 
     def test_given_cels_of_forwarded_call_when_generate_call_log_then_requested_different_from_destination(
         self,
     ):
+        self.confd.set_users(
+            MockUser(USER_1_UUID, USERS_TENANT, line_ids=[1]),
+            MockUser(USER_2_UUID, USERS_TENANT, line_ids=[2]),
+        )
         self.confd.set_lines(
             MockLine(
                 id=1,
                 name='101',
+                users=[{'uuid': USER_1_UUID}],
                 tenant_uuid=USERS_TENANT,
                 extensions=[{'exten': '101', 'context': 'default'}],
             ),
             MockLine(
                 id=2,
                 name='rku3uo',
+                users=[{'uuid': USER_2_UUID}],
                 tenant_uuid=USERS_TENANT,
                 extensions=[{'exten': '103', 'context': 'default'}],
             ),
@@ -378,10 +384,12 @@ LINKEDID_END | 2015-06-18 14:09:02.272325 | SIP/as2mkq-0000001f | 1434650936.31 
     def test_given_incoming_call_when_generate_call_log_then_requested_internal_extension_is_set(
         self,
     ):
+        self.confd.set_users(MockUser(USER_1_UUID, USERS_TENANT, line_ids=[1]),)
         self.confd.set_lines(
             MockLine(
                 id=1,
                 name='101',
+                users=[{'uuid': USER_1_UUID}],
                 tenant_uuid=USERS_TENANT,
                 extensions=[{'exten': '101', 'context': 'default'}],
             )

--- a/wazo_call_logd/tests/test_cel_interpretor.py
+++ b/wazo_call_logd/tests/test_cel_interpretor.py
@@ -13,7 +13,6 @@ from ..cel_interpretor import (
     CallerCELInterpretor,
     DispatchCELInterpretor,
     find_participant,
-    find_main_internal_extension,
 )
 from ..raw_call_log import RawCallLog
 
@@ -60,7 +59,7 @@ class TestFindParticipant(TestCase):
             'tenant_uuid': 'tenant_uuid',
             'userfield': 'user_userfield, toto',
         }
-        lines = [{'id': 12, 'users': [user]}]
+        lines = [{'id': 12, 'users': [user], 'extensions': []}]
         confd = confd_mock(lines)
         channame = 'sip/something-suffix'
 
@@ -75,43 +74,6 @@ class TestFindParticipant(TestCase):
                 tags=['user_userfield', 'toto'],
             ),
         )
-
-
-class TestFindMainInternalExtension(TestCase):
-    def test_find_main_internal_extension_when_channame_is_not_parsable(self):
-        confd = confd_mock()
-        channame = 'something'
-
-        result = find_main_internal_extension(confd, channame)
-
-        assert_that(result, none())
-
-    def test_find_main_internal_extension_when_no_lines(self):
-        confd = confd_mock()
-        channame = 'sip/something-suffix'
-
-        result = find_main_internal_extension(confd, channame)
-
-        assert_that(result, none())
-
-    def test_find_main_internal_extension_when_line_has_no_extensions(self):
-        lines = [{'id': 12, 'extensions': []}]
-        confd = confd_mock(lines)
-        channame = 'sip/something-suffix'
-
-        result = find_main_internal_extension(confd, channame)
-
-        assert_that(result, none())
-
-    def test_find_main_internal_extension_when_line_has_user(self):
-        extension = {'exten': '101', 'context': 'default'}
-        lines = [{'id': 12, 'extensions': [extension], 'tenant_uuid': 'tenant'}]
-        confd = confd_mock(lines)
-        channame = 'sip/something-suffix'
-
-        result = find_main_internal_extension(confd, channame)
-
-        assert_that(result, equal_to(extension))
 
 
 class TestCELDispatcher(TestCase):


### PR DESCRIPTION
Why:

* When interpreting a call, for each channel, wazo-call-logd would call
  wazo-confd twice to get the lines matching the name from the channel.
  Since we already have the information from the first call to wazo-confd,
  we can reuse it.

How:

* Store the main extension information in the participant and reuse it
  when needed. Note: this is actually the main extension of the given
  line, not the main extension of the main line of the user.

Note:

* Tests needed adjustment to link users to the lines, which was not
necessary before.