### PR TITLE
test-requirements: use pyhamcrest version lower than 1.10

### DIFF
--- a/integration_tests/test-requirements-for-tox.txt
+++ b/integration_tests/test-requirements-for-tox.txt
@@ -8,7 +8,7 @@ kombu
 nose
 openapi-spec-validator
 psycopg2-binary  # from sqlalchemy
-pyhamcrest
+pyhamcrest!=1.10.0  # Version 1.10.0 is broken
 requests
 sqlalchemy
 stevedore  # from wazo-call-logd-client

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
 mock
 nose
-pyhamcrest
+pyhamcrest!=1.10.0  # Version 1.10.0 is broken

--- a/zuul.yaml
+++ b/zuul.yaml
@@ -3,6 +3,9 @@
     parent: wazo-tox-integration
     required-projects:
       wazo-platform/xivo-manage-db
+    vars:
+      docker_compose_services_override:
+        - call-logd
 
 - project:
     templates:
@@ -17,4 +20,3 @@
       jobs:
         - wazo-tox-integration-call-logd:
             nodeset: debian10-vm
-


### PR DESCRIPTION
reason: it is broken