### PR TITLE
integration tests: freeze pyhamcrest==1.9.0

### DIFF
--- a/integration_tests/test-requirements-for-tox.txt
+++ b/integration_tests/test-requirements-for-tox.txt
@@ -8,7 +8,7 @@ kombu
 nose
 openapi-spec-validator
 psycopg2-binary  # from sqlalchemy
-pyhamcrest!=1.10.0  # Version 1.10.0 is broken
+pyhamcrest==1.9.0  # Versions 1.10.x are broken
 requests
 sqlalchemy
 stevedore  # from wazo-call-logd-client


### PR DESCRIPTION
Why:

* pyhamcrest 1.10.0 and 1.10.1 break backward compatibility.