### PR TITLE
test: remove silence loggers

### DIFF
--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -41,7 +41,6 @@ from .database import DbHelper
 
 urllib3.disable_warnings()
 logger = logging.getLogger(__name__)
-logging.getLogger('amqp').setLevel(logging.INFO)
 
 
 def cdr(


### PR DESCRIPTION
reason: loggers already silenced by xivo-test-helpers