### PR TITLE
Pull request for WAZO-1842-remove-pid

### DIFF
--- a/debian/wazo-call-logd.service
+++ b/debian/wazo-call-logd.service
@@ -2,12 +2,13 @@
 Description=wazo-call-logd server
 ConditionPathExists=!/var/lib/wazo/disabled
 After=network.target asterisk.service postgresql.service
-Before=monit.service
+StartLimitBurst=15
+StartLimitIntervalSec=150
 
 [Service]
-ExecStartPre=/usr/bin/install -d -o wazo-call-logd -g wazo-call-logd /run/wazo-call-logd
 ExecStart=/usr/bin/wazo-call-logd
-PIDFile=/run/wazo-call-logd/wazo-call-logd.pid
+Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target

--- a/wazo_call_logd/bin/daemon.py
+++ b/wazo_call_logd/bin/daemon.py
@@ -8,14 +8,12 @@ from functools import partial
 
 import xivo_dao
 from xivo.config_helper import set_xivo_uuid
-from xivo.daemonize import pidfile_context
 from xivo.user_rights import change_user
 from xivo.xivo_logging import setup_logging, silence_loggers
 from wazo_call_logd.config import load as load_config
 from wazo_call_logd.controller import Controller
 
 logger = logging.getLogger(__name__)
-FOREGROUND = True  # Always in foreground systemd takes care of daemonizing
 
 
 def main(argv):
@@ -25,7 +23,9 @@ def main(argv):
     if user:
         change_user(user)
 
-    setup_logging(config['logfile'], FOREGROUND, config['debug'], config['log_level'])
+    setup_logging(
+        config['logfile'], debug=config['debug'], log_level=config['log_level']
+    )
     silence_loggers(['amqp'], level=logging.WARNING)
     xivo_dao.init_db_from_config(config)
 
@@ -34,8 +34,7 @@ def main(argv):
     controller = Controller(config)
     signal.signal(signal.SIGTERM, partial(sigterm, controller))
 
-    with pidfile_context(config['pidfile'], FOREGROUND):
-        controller.run()
+    controller.run()
 
 
 def sigterm(controller, signum, frame):

--- a/wazo_call_logd/bin/main.py
+++ b/wazo_call_logd/bin/main.py
@@ -58,7 +58,7 @@ DEFAULT_CONFIG = {
 
 def main():
     _print_deprecation_notice()
-    setup_logging('/dev/null', FOREGROUND, debug=False)
+    setup_logging('/dev/null', debug=False)
     silence_loggers(['urllib3.connectionpool'], level=logging.WARNING)
     with pidfile_context(PIDFILENAME, FOREGROUND):
         _generate_call_logs()

--- a/wazo_call_logd/config.py
+++ b/wazo_call_logd/config.py
@@ -11,7 +11,6 @@ from xivo.xivo_logging import get_log_level_by_name
 _DEFAULT_CONFIG = {
     'logfile': '/var/log/wazo-call-logd.log',
     'log_level': 'info',
-    'pidfile': '/run/wazo-call-logd/wazo-call-logd.pid',
     'config_file': '/etc/wazo-call-logd/config.yml',
     'extra_config_files': '/etc/wazo-call-logd/conf.d',
     'debug': False,


### PR DESCRIPTION
## remove usage of PID file and use systemd options

reason: systemd restart remove monit usage based on pid file

## remove unused FOREGROUND arg in setup_logging