### PR TITLE
10s is better, in particular for VM

### DIFF
--- a/etc/wazo-call-logd/config.yml
+++ b/etc/wazo-call-logd/config.yml
@@ -46,7 +46,7 @@ auth:
   port: 9497
   prefix: null
   https: false
-  timeout: 2
+  timeout: 10
   key_file: /var/lib/wazo-auth-keys/wazo-call-logd-key.yml
 
 # wazo-confd (configuration daemon) connection informations.

--- a/etc/wazo-call-logd/config.yml
+++ b/etc/wazo-call-logd/config.yml
@@ -46,7 +46,6 @@ auth:
   port: 9497
   prefix: null
   https: false
-  timeout: 10
   key_file: /var/lib/wazo-auth-keys/wazo-call-logd-key.yml
 
 # wazo-confd (configuration daemon) connection informations.

--- a/wazo_call_logd/bin/main.py
+++ b/wazo_call_logd/bin/main.py
@@ -37,7 +37,6 @@ DEFAULT_CONFIG = {
     'auth': {
         'host': 'localhost',
         'port': 9497,
-        'timeout': 2,
         'prefix': None,
         'https': False,
         'key_file': '/var/lib/wazo-auth-keys/wazo-call-logd-key.yml',

--- a/wazo_call_logd/config.py
+++ b/wazo_call_logd/config.py
@@ -40,7 +40,6 @@ _DEFAULT_CONFIG = {
         'port': 9497,
         'prefix': None,
         'https': False,
-        'timeout': 2,
         'key_file': '/var/lib/wazo-auth-keys/wazo-call-logd-key.yml',
     },
     'confd': {'host': 'localhost', 'port': 9486, 'prefix': None, 'https': False},


### PR DESCRIPTION
As per the other authentification timeouts, there is no reason to have 2 s instead of 10, isn't there ?