### PR TITLE
WAZO-2250 Pull request for extract-tenant-from-query

### DIFF
--- a/integration_tests/suite/test_cdr_recording.py
+++ b/integration_tests/suite/test_cdr_recording.py
@@ -1,6 +1,8 @@
 # Copyright 2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import requests
+
 from hamcrest import (
     assert_that,
     calling,
@@ -13,6 +15,7 @@ from xivo_test_helpers.hamcrest.raises import raises
 from .helpers.base import IntegrationTest
 from .helpers.constants import (
     MASTER_TENANT as MAIN_TENANT,
+    MASTER_TOKEN as MAIN_TOKEN,
     OTHER_TENANT as SUB_TENANT,
 )
 from .helpers.database import call_log
@@ -125,3 +128,24 @@ class TestRecording(IntegrationTest):
             11, rec_uuid, tenant_uuid=MAIN_TENANT
         )
         assert_that(response.text, equal_to('11-recording'))
+
+    @call_log(
+        **{'id': 1},
+        tenant_uuid=MAIN_TENANT,
+        recordings=[{'path': '/tmp/foobar.wav'}],
+    )
+    def test_get_media_using_token_tenant_query_string(self):
+        cdr_id = 1
+        self.filesystem.create_file('/tmp/foobar.wav', content='my-recording-content')
+        recording_uuid = self.call_logd.cdr.get_by_id(cdr_id)['recordings'][0]['uuid']
+        port = self.service_port(9298, 'call-logd')
+        base_url = f'http://localhost:{port}/1.0'
+        api_url = f'{base_url}/cdr/{cdr_id}/recordings/{recording_uuid}/media'
+
+        params = {'tenant': MAIN_TENANT, 'token': MAIN_TOKEN}
+        response = requests.get(api_url, params=params)
+        assert_that(response.text, equal_to('my-recording-content'))
+
+        params = {'tenant': SUB_TENANT, 'token': MAIN_TOKEN}
+        response = requests.get(api_url, params=params)
+        assert_that(response.status_code, equal_to(404))

--- a/wazo_call_logd/plugins/cdr/api.yml
+++ b/wazo_call_logd/plugins/cdr/api.yml
@@ -52,7 +52,10 @@ paths:
   /cdr/{cdr_id}/recordings/{recording_uuid}/media:
     get:
       summary: Get a recording media
-      description: '**Required ACL:** `call-logd.cdr.{cdr_id}.recordings.{recording_uuid}.media.read`'
+      description: |
+        **Required ACL:** `call-logd.cdr.{cdr_id}.recordings.{recording_uuid}.media.read`
+
+        This endpoint allow to use `?token={token_uuid}` and `?tenant={tenant_uuid}` query string to bypass headers
       tags:
         - cdr
       parameters:

--- a/wazo_call_logd/plugins/cdr/schemas.py
+++ b/wazo_call_logd/plugins/cdr/schemas.py
@@ -112,9 +112,6 @@ class CDRListRequestSchema(Schema):
 
 
 class CDRSchemaList(Schema):
-    class Meta:
-        ordered = True
-
     items = fields.Nested(CDRSchema, many=True)
     total = fields.Integer()
     filtered = fields.Integer()


### PR DESCRIPTION
Depends-on: https://github.com/wazo-platform/xivo-lib-python/pull/68

reason: To allow to download file directly by the browser

note: since we do not extract token from query for all endpoints and for
all actions (verify acl + verify tenant). We cannot extract from
query every time when checking tenant against token and not when
checking acl. It may result in a small security issue. That's why the
token helper extract from query only for this endpoint