### PR TITLE
Pull request for WAZO-2148-duplicate-call-participants

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,12 @@ wazo-call-logd is a service for collecting statistics on calls made on a Wazo se
 ```shell
 tox --recreate -e py37
 ```
+
+## Developing integration tests
+
+To extract CELs of the latest call from a real Wazo Platform instance and insert
+them into an integration test:
+
+```
+sudo -u postgres psql asterisk -c "select eventtype,eventtime,channame,uniqueid,linkedid from cel where linkedid = (select max(linkedid) from cel) order by eventtime"
+```

--- a/integration_tests/suite/test_call_log_generation.py
+++ b/integration_tests/suite/test_call_log_generation.py
@@ -4,10 +4,13 @@
 from datetime import datetime
 from hamcrest import (
     assert_that,
+    all_of,
     contains_inanyorder,
     empty,
     has_entries,
+    has_item,
     has_key,
+    has_length,
     has_properties,
     is_,
     not_,
@@ -1113,5 +1116,84 @@ LINKEDID_END | 2015-06-18 14:09:02.272325 | SIP/as2mkq-0000001f | 1434650936.31 
                 source_line_identity='pjsip/svlhxtj3',
                 destination_line_identity='pjsip/o7r761lt',
                 destination_user_uuid=USER_2_UUID,
+            ),
+        )
+
+    @raw_cels(
+        '''\
+   eventtype   |           eventtime           |           channame           |    uniqueid    |    linkedid
+--------------+-------------------------------+------------------------------+----------------+----------------
+ CHAN_START   | 2021-03-10 15:52:46.207359-05 | SCCP/101-0000000b            | 1615409566.206 | 1615409566.206
+ CHAN_START   | 2021-03-10 15:52:46.427365-05 | Local/104@default-0000004f;1 | 1615409566.207 | 1615409566.206
+ CHAN_START   | 2021-03-10 15:52:46.427441-05 | Local/104@default-0000004f;2 | 1615409566.208 | 1615409566.206
+ CHAN_START   | 2021-03-10 15:52:46.869701-05 | PJSIP/mvkph8he-00000025      | 1615409566.209 | 1615409566.206
+ WAZO_USER    | 2021-03-10 15:52:46.873033-05 | PJSIP/mvkph8he-00000025      | 1615409566.209 | 1615409566.206
+ CHAN_END     | 2021-03-10 15:53:01.501216-05 | Local/104@default-0000004f;1 | 1615409566.207 | 1615409566.206
+ HANGUP       | 2021-03-10 15:53:01.501216-05 | Local/104@default-0000004f;1 | 1615409566.207 | 1615409566.206
+ HANGUP       | 2021-03-10 15:53:01.503904-05 | Local/104@default-0000004f;2 | 1615409566.208 | 1615409566.206
+ CHAN_END     | 2021-03-10 15:53:01.503904-05 | Local/104@default-0000004f;2 | 1615409566.208 | 1615409566.206
+ CHAN_END     | 2021-03-10 15:53:01.506432-05 | PJSIP/mvkph8he-00000025      | 1615409566.209 | 1615409566.206
+ HANGUP       | 2021-03-10 15:53:01.506432-05 | PJSIP/mvkph8he-00000025      | 1615409566.209 | 1615409566.206
+ CHAN_START   | 2021-03-10 15:53:06.501732-05 | Local/104@default-00000050;1 | 1615409586.210 | 1615409566.206
+ CHAN_START   | 2021-03-10 15:53:06.501859-05 | Local/104@default-00000050;2 | 1615409586.211 | 1615409566.206
+ CHAN_START   | 2021-03-10 15:53:06.792964-05 | PJSIP/mvkph8he-00000026      | 1615409586.212 | 1615409566.206
+ WAZO_USER    | 2021-03-10 15:53:06.796245-05 | PJSIP/mvkph8he-00000026      | 1615409586.212 | 1615409566.206
+ ANSWER       | 2021-03-10 15:53:08.641888-05 | PJSIP/mvkph8he-00000026      | 1615409586.212 | 1615409566.206
+ ANSWER       | 2021-03-10 15:53:08.642619-05 | Local/104@default-00000050;2 | 1615409586.211 | 1615409566.206
+ ANSWER       | 2021-03-10 15:53:08.645208-05 | Local/104@default-00000050;1 | 1615409586.210 | 1615409566.206
+ BRIDGE_ENTER | 2021-03-10 15:53:08.651079-05 | PJSIP/mvkph8he-00000026      | 1615409586.212 | 1615409566.206
+ BRIDGE_ENTER | 2021-03-10 15:53:08.651592-05 | Local/104@default-00000050;2 | 1615409586.211 | 1615409566.206
+ ANSWER       | 2021-03-10 15:53:09.258801-05 | SCCP/101-0000000b            | 1615409566.206 | 1615409566.206
+ BRIDGE_ENTER | 2021-03-10 15:53:09.260174-05 | Local/104@default-00000050;1 | 1615409586.210 | 1615409566.206
+ BRIDGE_ENTER | 2021-03-10 15:53:09.261166-05 | SCCP/101-0000000b            | 1615409566.206 | 1615409566.206
+ BRIDGE_EXIT  | 2021-03-10 15:53:09.275335-05 | PJSIP/mvkph8he-00000026      | 1615409586.212 | 1615409566.206
+ BRIDGE_EXIT  | 2021-03-10 15:53:09.275506-05 | Local/104@default-00000050;1 | 1615409586.210 | 1615409566.206
+ BRIDGE_ENTER | 2021-03-10 15:53:09.275531-05 | PJSIP/mvkph8he-00000026      | 1615409586.212 | 1615409566.206
+ CHAN_END     | 2021-03-10 15:53:09.276109-05 | Local/104@default-00000050;1 | 1615409586.210 | 1615409566.206
+ HANGUP       | 2021-03-10 15:53:09.276109-05 | Local/104@default-00000050;1 | 1615409586.210 | 1615409566.206
+ BRIDGE_EXIT  | 2021-03-10 15:53:09.277653-05 | Local/104@default-00000050;2 | 1615409586.211 | 1615409566.206
+ HANGUP       | 2021-03-10 15:53:09.277997-05 | Local/104@default-00000050;2 | 1615409586.211 | 1615409566.206
+ CHAN_END     | 2021-03-10 15:53:09.277997-05 | Local/104@default-00000050;2 | 1615409586.211 | 1615409566.206
+ BRIDGE_EXIT  | 2021-03-10 15:53:10.292963-05 | PJSIP/mvkph8he-00000026      | 1615409586.212 | 1615409566.206
+ BRIDGE_EXIT  | 2021-03-10 15:53:10.294797-05 | SCCP/101-0000000b            | 1615409566.206 | 1615409566.206
+ HANGUP       | 2021-03-10 15:53:10.29554-05  | SCCP/101-0000000b            | 1615409566.206 | 1615409566.206
+ CHAN_END     | 2021-03-10 15:53:10.29554-05  | SCCP/101-0000000b            | 1615409566.206 | 1615409566.206
+ CHAN_END     | 2021-03-10 15:53:10.29859-05  | PJSIP/mvkph8he-00000026      | 1615409586.212 | 1615409566.206
+ HANGUP       | 2021-03-10 15:53:10.29859-05  | PJSIP/mvkph8he-00000026      | 1615409586.212 | 1615409566.206
+ LINKEDID_END | 2021-03-10 15:53:10.29859-05  | PJSIP/mvkph8he-00000026      | 1615409586.212 | 1615409566.206
+    '''
+    )
+    def test_group_call_has_no_duplicate_participant(self):
+        self.confd.set_users(
+            MockUser(USER_1_UUID, USERS_TENANT, line_ids=[1]),
+            MockUser(USER_2_UUID, USERS_TENANT, line_ids=[2]),
+        )
+        self.confd.set_lines(
+            MockLine(
+                id=1,
+                name='101',
+                users=[{'uuid': USER_1_UUID}],
+                tenant_uuid=USERS_TENANT,
+                extensions=[{'exten': '101', 'context': 'default'}],
+            ),
+            MockLine(
+                id=2,
+                name='mvkph8he',
+                users=[{'uuid': USER_2_UUID}],
+                tenant_uuid=USERS_TENANT,
+                extensions=[{'exten': '102', 'context': 'default'}],
+            ),
+        )
+        self.confd.set_contexts(
+            MockContext(id=1, name='default', tenant_uuid=USERS_TENANT)
+        )
+
+        self._assert_last_call_log_matches(
+            '1615409566.206',
+            has_properties(
+                participants=all_of(
+                    has_length(2),
+                    has_item(has_properties(user_uuid=USER_2_UUID, answered=True)),
+                )
             ),
         )

--- a/integration_tests/suite/test_call_logs_cli.py
+++ b/integration_tests/suite/test_call_logs_cli.py
@@ -8,7 +8,7 @@ from datetime import (
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     contains_string,
     empty,
@@ -275,7 +275,7 @@ LINKEDID_END | 2013-01-01 08:00:11 | Bob Marley    |    1002 | s     | user    |
         self.docker_exec(['wazo-call-logs', 'delete', '--days', '1'])
 
         result = self.session.query(CallLog).all()
-        assert_that(result, contains(has_properties(id=2)))
+        assert_that(result, contains_exactly(has_properties(id=2)))
 
         result = self.session.query(Recording).all()
-        assert_that(result, contains(has_properties(call_log_id=2)))
+        assert_that(result, contains_exactly(has_properties(call_log_id=2)))

--- a/integration_tests/suite/test_cdr.py
+++ b/integration_tests/suite/test_cdr.py
@@ -9,7 +9,7 @@ from hamcrest import (
     any_of,
     assert_that,
     calling,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     equal_to,
     empty,
@@ -647,7 +647,7 @@ class TestListCDR(IntegrationTest):
             result_start_asc,
             has_entry(
                 'items',
-                contains(
+                contains_exactly(
                     has_entries(start='2017-04-10T00:00:00+00:00'),
                     has_entries(start='2017-04-11T00:00:00+00:00'),
                     has_entries(start='2017-04-12T00:00:00+00:00'),
@@ -659,7 +659,7 @@ class TestListCDR(IntegrationTest):
             result_start_desc,
             has_entry(
                 'items',
-                contains(
+                contains_exactly(
                     has_entries(start='2017-04-12T00:00:00+00:00'),
                     has_entries(start='2017-04-11T00:00:00+00:00'),
                     has_entries(start='2017-04-10T00:00:00+00:00'),
@@ -671,7 +671,7 @@ class TestListCDR(IntegrationTest):
             result_duration,
             has_entry(
                 'items',
-                contains(
+                contains_exactly(
                     has_entries(duration=0),
                     has_entries(duration=1),
                     has_entries(duration=2),
@@ -692,7 +692,7 @@ class TestListCDR(IntegrationTest):
 
         assert_that(
             duration_asc['items'],
-            contains(
+            contains_exactly(
                 has_entries(duration=None),
                 has_entries(duration=1),
                 has_entries(duration=2),
@@ -700,7 +700,7 @@ class TestListCDR(IntegrationTest):
         )
         assert_that(
             duration_desc['items'],
-            contains(
+            contains_exactly(
                 has_entries(duration=2),
                 has_entries(duration=1),
                 has_entries(duration=None),
@@ -719,7 +719,9 @@ class TestListCDR(IntegrationTest):
         assert_that(
             result_paginated,
             has_entries(
-                filtered=3, total=3, items=contains(result_unpaginated['items'][1])
+                filtered=3,
+                total=3,
+                items=contains_exactly(result_unpaginated['items'][1]),
             ),
         )
 
@@ -764,7 +766,7 @@ class TestListCDR(IntegrationTest):
     def test_search_by_filename(self):
         expected = self.call_logd.cdr.list()['items'][0]
         result = self.call_logd.cdr.list(search=expected['recordings'][0]['filename'])
-        assert_that(result, has_entries(items=contains(expected)))
+        assert_that(result, has_entries(items=contains_exactly(expected)))
 
     @call_logs(number=1100)
     def test_list_default_limit(self):
@@ -1072,7 +1074,9 @@ class TestListCDR(IntegrationTest):
     def test_negative_duration_then_duration_is_zero(self):
         result = self.call_logd.cdr.list()
 
-        assert_that(result, has_entry('items', contains(has_entries(duration=0))))
+        assert_that(
+            result, has_entry('items', contains_exactly(has_entries(duration=0)))
+        )
 
     @call_log(date='2017-04-10')
     @call_log(date='2017-04-11', participants=[{'user_uuid': USER_1_UUID}])
@@ -1090,7 +1094,7 @@ class TestListCDR(IntegrationTest):
             has_entries(
                 filtered=4,
                 total=6,
-                items=contains(
+                items=contains_exactly(
                     has_entries(start='2017-04-13T00:00:00+00:00'),
                     has_entries(start='2017-04-12T00:00:00+00:00'),
                 ),
@@ -1239,7 +1243,7 @@ class TestListCDR(IntegrationTest):
         assert_that(results['total'], equal_to(1))
         assert_that(
             results['items'],
-            contains(
+            contains_exactly(
                 has_entries(source_user_uuid=USER_1_UUID, tenant_uuid=USERS_TENANT)
             ),
         )
@@ -1249,7 +1253,7 @@ class TestListCDR(IntegrationTest):
         assert_that(results['filtered'], equal_to(1))
         assert_that(
             results['items'],
-            contains(
+            contains_exactly(
                 has_entries(source_user_uuid=USER_2_UUID, tenant_uuid=USERS_TENANT)
             ),
         )
@@ -1263,7 +1267,7 @@ class TestListCDR(IntegrationTest):
         assert_that(results['total'], equal_to(1))
         assert_that(
             results['items'],
-            contains(
+            contains_exactly(
                 has_entries(source_user_uuid=USER_2_UUID, tenant_uuid=USERS_TENANT)
             ),
         )
@@ -1273,7 +1277,7 @@ class TestListCDR(IntegrationTest):
         assert_that(results['total'], equal_to(1))
         assert_that(
             results['items'],
-            contains(
+            contains_exactly(
                 has_entries(source_user_uuid=OTHER_USER_UUID, tenant_uuid=OTHER_TENANT)
             ),
         )

--- a/integration_tests/suite/test_db_call_log.py
+++ b/integration_tests/suite/test_db_call_log.py
@@ -7,7 +7,7 @@ from datetime import (
 )
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     has_entries,
     has_length,
@@ -55,7 +55,7 @@ class TestCallLog(DBIntegrationTest):
         result = self.dao.call_log.find_all_in_period(params)
         assert_that(
             result[0].recordings,
-            contains(
+            contains_exactly(
                 has_properties(uuid=rec2['uuid']),
                 has_properties(uuid=rec1['uuid']),
             ),
@@ -110,7 +110,7 @@ class TestCallLog(DBIntegrationTest):
         self.dao.call_log.delete_from_list([id_1, id_3])
 
         result = self.session.query(CallLog).all()
-        assert_that(result, contains(has_property('id', id_2)))
+        assert_that(result, contains_exactly(has_property('id', id_2)))
 
     @call_log(**cdr(id_=1))
     @call_log(**cdr(id_=2))
@@ -129,4 +129,4 @@ class TestCallLog(DBIntegrationTest):
         self.dao.call_log.delete(older=older)
 
         result = self.session.query(CallLog).all()
-        assert_that(result, contains(has_property('id', 2)))
+        assert_that(result, contains_exactly(has_property('id', 2)))

--- a/integration_tests/suite/test_db_cel.py
+++ b/integration_tests/suite/test_db_cel.py
@@ -4,7 +4,7 @@
 from datetime import timedelta as td
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     empty,
     has_property,
@@ -120,7 +120,7 @@ class TestCEL(DBIntegrationTest):
         result = self.dao.cel.find_last_unprocessed(limit=2)
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_property('id', cel2['id']),
                 has_property('id', cel3['id']),
             ),
@@ -132,7 +132,7 @@ class TestCEL(DBIntegrationTest):
         result = self.dao.cel.find_last_unprocessed(limit=10)
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_property('id', cel1['id']),
                 has_property('id', cel2['id']),
             ),
@@ -146,7 +146,7 @@ class TestCEL(DBIntegrationTest):
         result = self.dao.cel.find_last_unprocessed(limit=1)
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_property('id', cel1['id']),
                 has_property('id', cel2['id']),
             ),
@@ -162,7 +162,7 @@ class TestCEL(DBIntegrationTest):
         result = self.dao.cel.find_last_unprocessed(limit=2)
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_property('id', cel1['id']),
                 has_property('id', cel2['id']),
                 has_property('id', cel3['id']),
@@ -186,7 +186,7 @@ class TestCEL(DBIntegrationTest):
         result = self.dao.cel.find_last_unprocessed(limit=10)
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_property('id', cel3['id']),
                 has_property('id', cel4['id']),
             ),
@@ -202,7 +202,7 @@ class TestCEL(DBIntegrationTest):
         result = self.dao.cel.find_last_unprocessed(limit=10)
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_property('id', cel1['id']),
                 has_property('id', cel2['id']),
                 has_property('id', cel3['id']),
@@ -236,7 +236,7 @@ class TestCEL(DBIntegrationTest):
         result = self.dao.cel.find_from_linked_id('666')
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_property('id', cel2['id']),
                 has_property('id', cel1['id']),
                 has_property('id', cel3['id']),
@@ -256,7 +256,7 @@ class TestCEL(DBIntegrationTest):
         result = self.dao.cel.find_last_unprocessed(older=older)
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_property('id', cel2['id']),
                 has_property('id', cel3['id']),
             ),
@@ -269,7 +269,7 @@ class TestCEL(DBIntegrationTest):
         result = self.dao.cel.find_last_unprocessed(older=older)
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_property('id', cel1['id']),
                 has_property('id', cel2['id']),
             ),
@@ -284,7 +284,7 @@ class TestCEL(DBIntegrationTest):
         result = self.dao.cel.find_last_unprocessed(older=older)
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_property('id', cel1['id']),
                 has_property('id', cel2['id']),
             ),

--- a/integration_tests/test-requirements-for-tox.txt
+++ b/integration_tests/test-requirements-for-tox.txt
@@ -6,7 +6,7 @@ kombu
 marshmallow==3.0.0b14
 mock
 openapi-spec-validator
-pyhamcrest==1.9.0  # Versions 1.10.x are broken
+pyhamcrest
 pytest
 python-dateutil==2.7.3  # from marshmallow, to accept more date formats
 pytz==2019.1

--- a/wazo_call_logd/cel_interpretor.py
+++ b/wazo_call_logd/cel_interpretor.py
@@ -6,77 +6,15 @@ import re
 import logging
 
 from xivo.asterisk.line_identity import identity_from_channel
-from xivo.asterisk.protocol_interface import protocol_interface_from_channel
-from xivo.asterisk.protocol_interface import InvalidChannelError
 
 from .database.cel_event_type import CELEventType
 from .database.models import CallLogParticipant, Recording
+from .participant import find_participant
 
 
 logger = logging.getLogger(__name__)
 
 EXTRA_USER_FWD_REGEX = r'^.*NUM: *(.*?) *, *CONTEXT: *(.*?) *, *NAME: *(.*?) *(?:,|"})'
-
-
-def find_participant(confd, channame):
-    # TODO PJSIP clean after migration
-    channame = channame.replace('PJSIP', 'SIP')
-
-    try:
-        protocol, line_name = protocol_interface_from_channel(channame)
-    except InvalidChannelError:
-        return None
-
-    if protocol == 'Local':
-        logger.debug('Ignoring participant %s', channame)
-        return None
-
-    logger.debug(
-        'Looking up participant with protocol %s and line name "%s"',
-        protocol,
-        line_name,
-    )
-    lines = confd.lines.list(name=line_name, recurse=True)['items']
-    if not lines:
-        return
-
-    line = lines[0]
-    logger.debug('Found participant line id %s', line['id'])
-    users = line['users']
-    if not users:
-        return
-
-    user = confd.users.get(users[0]['uuid'])
-    tags = (
-        [tag.strip() for tag in user['userfield'].split(',')]
-        if user['userfield']
-        else []
-    )
-    logger.debug(
-        'Found participant user uuid %s tenant uuid %s',
-        user['uuid'],
-        user['tenant_uuid'],
-    )
-
-    extensions = line['extensions']
-    if extensions:
-        main_extension = extensions[0]
-
-        logger.debug(
-            'Found main internal extension %s@%s',
-            main_extension['exten'],
-            main_extension['context'],
-        )
-    else:
-        main_extension = None
-
-    return {
-        'uuid': user['uuid'],
-        'tenant_uuid': user['tenant_uuid'],
-        'line_id': line['id'],
-        'tags': tags,
-        'main_extension': main_extension,
-    }
 
 
 def extract_mixmonitor_extra(extra):

--- a/wazo_call_logd/cel_interpretor.py
+++ b/wazo_call_logd/cel_interpretor.py
@@ -103,7 +103,7 @@ class AbstractCELInterpretor:
 
 
 class CallerCELInterpretor(AbstractCELInterpretor):
-    def __init__(self, confd):
+    def __init__(self):
         self.eventtype_map = {
             CELEventType.chan_start: self.interpret_chan_start,
             CELEventType.chan_end: self.interpret_chan_end,
@@ -118,7 +118,6 @@ class CallerCELInterpretor(AbstractCELInterpretor):
             CELEventType.xivo_outcall: self.interpret_xivo_outcall,
             CELEventType.xivo_user_fwd: self.interpret_xivo_user_fwd,
         }
-        self._confd = confd
 
     def interpret_chan_start(self, cel, call):
         call.date = cel.eventtime
@@ -217,7 +216,7 @@ class CallerCELInterpretor(AbstractCELInterpretor):
 
 
 class CalleeCELInterpretor(AbstractCELInterpretor):
-    def __init__(self, confd):
+    def __init__(self):
         self.eventtype_map = {
             CELEventType.chan_start: self.interpret_chan_start,
             CELEventType.chan_end: self.interpret_chan_end,
@@ -226,7 +225,6 @@ class CalleeCELInterpretor(AbstractCELInterpretor):
             CELEventType.mixmonitor_start: self.interpret_mixmonitor_start,
             CELEventType.mixmonitor_stop: self.interpret_mixmonitor_stop,
         }
-        self._confd = confd
 
     def interpret_chan_start(self, cel, call):
         call.destination_line_identity = identity_from_channel(cel.channame)
@@ -285,9 +283,6 @@ class CalleeCELInterpretor(AbstractCELInterpretor):
 
 
 class LocalOriginateCELInterpretor:
-    def __init__(self, confd):
-        self._confd = confd
-
     def interpret_cels(self, cels, call):
         uniqueids = [cel.uniqueid for cel in cels if cel.eventtype == 'CHAN_START']
         try:

--- a/wazo_call_logd/controller.py
+++ b/wazo_call_logd/controller.py
@@ -35,10 +35,10 @@ class Controller:
         generator = CallLogsGenerator(
             confd_client,
             [
-                LocalOriginateCELInterpretor(confd_client),
+                LocalOriginateCELInterpretor(),
                 DispatchCELInterpretor(
-                    CallerCELInterpretor(confd_client),
-                    CalleeCELInterpretor(confd_client),
+                    CallerCELInterpretor(),
+                    CalleeCELInterpretor(),
                 ),
             ],
         )

--- a/wazo_call_logd/generator.py
+++ b/wazo_call_logd/generator.py
@@ -8,6 +8,7 @@ from itertools import groupby
 from operator import attrgetter
 from wazo_call_logd.exceptions import InvalidCallLogException
 from wazo_call_logd import raw_call_log
+from .participant import find_participant
 
 
 logger = logging.getLogger(__name__)

--- a/wazo_call_logd/main_sweep.py
+++ b/wazo_call_logd/main_sweep.py
@@ -71,10 +71,8 @@ def _generate_call_logs():
     generator = CallLogsGenerator(
         confd_client,
         [
-            LocalOriginateCELInterpretor(confd_client),
-            DispatchCELInterpretor(
-                CallerCELInterpretor(confd_client), CalleeCELInterpretor(confd_client)
-            ),
+            LocalOriginateCELInterpretor(),
+            DispatchCELInterpretor(CallerCELInterpretor(), CalleeCELInterpretor()),
         ],
     )
     token_renewer.subscribe_to_next_token_details_change(

--- a/wazo_call_logd/participant.py
+++ b/wazo_call_logd/participant.py
@@ -1,0 +1,70 @@
+# Copyright 2021 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import logging
+
+from xivo.asterisk.protocol_interface import protocol_interface_from_channel
+from xivo.asterisk.protocol_interface import InvalidChannelError
+
+logger = logging.getLogger(__name__)
+
+
+def find_participant(confd, channame):
+    # TODO PJSIP clean after migration
+    channame = channame.replace('PJSIP', 'SIP')
+
+    try:
+        protocol, line_name = protocol_interface_from_channel(channame)
+    except InvalidChannelError:
+        return None
+
+    if protocol == 'Local':
+        logger.debug('Ignoring participant %s', channame)
+        return None
+
+    logger.debug(
+        'Looking up participant with protocol %s and line name "%s"',
+        protocol,
+        line_name,
+    )
+    lines = confd.lines.list(name=line_name, recurse=True)['items']
+    if not lines:
+        return
+
+    line = lines[0]
+    logger.debug('Found participant line id %s', line['id'])
+    users = line['users']
+    if not users:
+        return
+
+    user = confd.users.get(users[0]['uuid'])
+    tags = (
+        [tag.strip() for tag in user['userfield'].split(',')]
+        if user['userfield']
+        else []
+    )
+    logger.debug(
+        'Found participant user uuid %s tenant uuid %s',
+        user['uuid'],
+        user['tenant_uuid'],
+    )
+
+    extensions = line['extensions']
+    if extensions:
+        main_extension = extensions[0]
+
+        logger.debug(
+            'Found main internal extension %s@%s',
+            main_extension['exten'],
+            main_extension['context'],
+        )
+    else:
+        main_extension = None
+
+    return {
+        'uuid': user['uuid'],
+        'tenant_uuid': user['tenant_uuid'],
+        'line_id': line['id'],
+        'tags': tags,
+        'main_extension': main_extension,
+    }

--- a/wazo_call_logd/plugins/support_center/tests/test_services.py
+++ b/wazo_call_logd/plugins/support_center/tests/test_services.py
@@ -1,4 +1,4 @@
-# Copyright 2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytz
@@ -6,7 +6,7 @@ import pytz
 from datetime import datetime
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
 )
 from unittest import TestCase
 
@@ -32,7 +32,7 @@ class TestSupportCenterService(TestCase):
         result = [(d1.isoformat(), d2.isoformat()) for d1, d2 in intervals]
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 (
                     '2020-10-10T00:00:00-04:00',
                     '2020-10-11T00:00:00-04:00',
@@ -59,7 +59,7 @@ class TestSupportCenterService(TestCase):
         result = [(d1.isoformat(), d2.isoformat()) for d1, d2 in intervals]
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 (
                     '2020-10-31T23:00:00-04:00',
                     '2020-11-01T00:00:00-04:00',
@@ -86,7 +86,7 @@ class TestSupportCenterService(TestCase):
         result = [(d1.isoformat(), d2.isoformat()) for d1, d2 in intervals]
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 (
                     '2020-10-31T00:00:00-04:00',
                     '2020-11-01T00:00:00-04:00',
@@ -109,7 +109,7 @@ class TestSupportCenterService(TestCase):
         result = [(d1.isoformat(), d2.isoformat()) for d1, d2 in intervals]
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 (
                     '2020-10-01T00:00:00-04:00',
                     '2020-11-01T00:00:00-04:00',
@@ -132,7 +132,7 @@ class TestSupportCenterService(TestCase):
         result = [(d1.isoformat(), d2.isoformat()) for d1, d2 in intervals]
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 (
                     '2020-03-07T23:00:00-05:00',
                     '2020-03-08T00:00:00-05:00',
@@ -163,7 +163,7 @@ class TestSupportCenterService(TestCase):
         result = [(d1.isoformat(), d2.isoformat()) for d1, d2 in intervals]
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 (
                     '2020-03-07T00:00:00-05:00',
                     '2020-03-08T00:00:00-05:00',
@@ -186,7 +186,7 @@ class TestSupportCenterService(TestCase):
         result = [(d1.isoformat(), d2.isoformat()) for d1, d2 in intervals]
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 (
                     '2020-03-01T00:00:00-05:00',
                     '2020-04-01T00:00:00-04:00',
@@ -202,7 +202,7 @@ class TestSupportCenterService(TestCase):
         intervals = list(self.service._generate_qos_interval([]))
         assert_that(
             intervals,
-            contains(
+            contains_exactly(
                 (0, None),
             ),
         )
@@ -211,7 +211,7 @@ class TestSupportCenterService(TestCase):
         intervals = list(self.service._generate_qos_interval([1]))
         assert_that(
             intervals,
-            contains(
+            contains_exactly(
                 (0, 1),
                 (1, None),
             ),
@@ -221,7 +221,7 @@ class TestSupportCenterService(TestCase):
         intervals = list(self.service._generate_qos_interval([1, 2, 3, 4]))
         assert_that(
             intervals,
-            contains(
+            contains_exactly(
                 (0, 1),
                 (1, 2),
                 (2, 3),

--- a/wazo_call_logd/raw_call_log.py
+++ b/wazo_call_logd/raw_call_log.py
@@ -3,6 +3,7 @@
 
 import logging
 
+from collections import defaultdict
 from wazo_call_logd.database.models import CallLog
 
 from wazo_call_logd.exceptions import InvalidCallLogException
@@ -32,6 +33,7 @@ class RawCallLog:
         self.date_answer = None
         self.source_line_identity = None
         self.direction = 'internal'
+        self.raw_participants = defaultdict(dict)
         self.participants = []
         self.participants_by_channame = {}
         self.recordings = []

--- a/wazo_call_logd/tests/test_cel_interpretor.py
+++ b/wazo_call_logd/tests/test_cel_interpretor.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     equal_to,
     has_entries,
     none,
@@ -94,7 +94,7 @@ class TestCELDispatcher(TestCase):
 
         result = self.cel_dispatcher.split_caller_callee_cels(cels)
 
-        assert_that(result, contains(contains(), contains()))
+        assert_that(result, contains_exactly(contains_exactly(), contains_exactly()))
 
     def test_split_caller_callee_cels_1_uniqueid(self):
         cels = cel_1, cel_2 = [
@@ -104,7 +104,9 @@ class TestCELDispatcher(TestCase):
 
         result = self.cel_dispatcher.split_caller_callee_cels(cels)
 
-        assert_that(result, contains(contains(cel_1, cel_2), contains()))
+        assert_that(
+            result, contains_exactly(contains_exactly(cel_1, cel_2), contains_exactly())
+        )
 
     def test_split_caller_callee_cels_2_uniqueids(self):
         cels = cel_1, cel_2, cel_3, cel_4 = [
@@ -116,7 +118,12 @@ class TestCELDispatcher(TestCase):
 
         result = self.cel_dispatcher.split_caller_callee_cels(cels)
 
-        assert_that(result, contains(contains(cel_1, cel_3), contains(cel_2, cel_4)))
+        assert_that(
+            result,
+            contains_exactly(
+                contains_exactly(cel_1, cel_3), contains_exactly(cel_2, cel_4)
+            ),
+        )
 
     def test_split_caller_callee_cels_3_uniqueids(self):
         cels = cel_1, cel_2, cel_3 = [
@@ -127,7 +134,10 @@ class TestCELDispatcher(TestCase):
 
         result = self.cel_dispatcher.split_caller_callee_cels(cels)
 
-        assert_that(result, contains(contains(cel_1), contains(cel_2, cel_3)))
+        assert_that(
+            result,
+            contains_exactly(contains_exactly(cel_1), contains_exactly(cel_2, cel_3)),
+        )
 
 
 class TestAbstractCELInterpretor(TestCase):

--- a/wazo_call_logd/tests/test_cel_interpretor.py
+++ b/wazo_call_logd/tests/test_cel_interpretor.py
@@ -25,16 +25,6 @@ from ..database.cel_event_type import CELEventType
 from ..raw_call_log import RawCallLog
 
 
-def confd_mock(lines=None):
-    lines = lines or []
-    confd = Mock()
-    confd.lines.list.return_value = {'items': lines}
-    confd.users.get.return_value = (
-        lines[0]['users'][0] if lines and lines[0].get('users') else None
-    )
-    return confd
-
-
 class TestExtractMixmonitorExtra:
     def test_valid_extra(self):
         extra = '{"key": "value", "key2": "value2"}'
@@ -197,7 +187,7 @@ class TestAbstractCELInterpretor(TestCase):
 
 class TestCallerCELInterpretor(TestCase):
     def setUp(self):
-        self.caller_cel_interpretor = CallerCELInterpretor(confd_mock())
+        self.caller_cel_interpretor = CallerCELInterpretor()
 
     def test_interpret_cel_unknown_or_ignored_event(self):
         cel = Mock(eventtype='unknown_or_ignored_eventtype')

--- a/wazo_call_logd/tests/test_cel_interpretor.py
+++ b/wazo_call_logd/tests/test_cel_interpretor.py
@@ -17,7 +17,6 @@ from ..cel_interpretor import (
     AbstractCELInterpretor,
     CallerCELInterpretor,
     DispatchCELInterpretor,
-    find_participant,
     extract_mixmonitor_extra,
     is_valid_mixmonitor_start_extra,
     is_valid_mixmonitor_stop_extra,
@@ -34,55 +33,6 @@ def confd_mock(lines=None):
         lines[0]['users'][0] if lines and lines[0].get('users') else None
     )
     return confd
-
-
-class TestFindParticipant(TestCase):
-    def test_find_participants_when_channame_is_not_parsable(self):
-        confd = confd_mock()
-        channame = 'something'
-
-        result = find_participant(confd, channame)
-
-        assert_that(result, none())
-
-    def test_find_participants_when_no_lines(self):
-        confd = confd_mock()
-        channame = 'sip/something-suffix'
-
-        result = find_participant(confd, channame)
-
-        assert_that(result, none())
-
-    def test_find_participants_when_line_has_no_user(self):
-        lines = [{'id': 12, 'users': []}]
-        confd = confd_mock(lines)
-        channame = 'sip/something-suffix'
-
-        result = find_participant(confd, channame)
-
-        assert_that(result, none())
-
-    def test_find_participants_when_line_has_user(self):
-        user = {
-            'uuid': 'user_uuid',
-            'tenant_uuid': 'tenant_uuid',
-            'userfield': 'user_userfield, toto',
-        }
-        lines = [{'id': 12, 'users': [user], 'extensions': []}]
-        confd = confd_mock(lines)
-        channame = 'sip/something-suffix'
-
-        result = find_participant(confd, channame)
-
-        assert_that(
-            result,
-            has_entries(
-                uuid='user_uuid',
-                tenant_uuid='tenant_uuid',
-                line_id=12,
-                tags=['user_userfield', 'toto'],
-            ),
-        )
 
 
 class TestExtractMixmonitorExtra:

--- a/wazo_call_logd/tests/test_generator.py
+++ b/wazo_call_logd/tests/test_generator.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 from hamcrest import all_of
 from hamcrest import assert_that
 from hamcrest import calling
-from hamcrest import contains
+from hamcrest import contains_exactly
 from hamcrest import contains_inanyorder
 from hamcrest import equal_to
 from hamcrest import has_property
@@ -63,7 +63,7 @@ class TestCallLogsGenerator(TestCase):
         result = self.generator.call_logs_from_cel(cels)
 
         self.interpretor.interpret_cels.assert_called_once_with(cels, call)
-        assert_that(result, contains(expected_call))
+        assert_that(result, contains_exactly(expected_call))
 
     @patch('wazo_call_logd.raw_call_log.RawCallLog')
     def test_call_logs_from_cel_two_calls(self, raw_call_log_constructor):
@@ -101,7 +101,7 @@ class TestCallLogsGenerator(TestCase):
 
         self.interpretor.interpret_cels.assert_any_call(cels_1, ANY)
         self.interpretor.interpret_cels.assert_any_call(cels_2, ANY)
-        assert_that(result, contains(expected_call_1))
+        assert_that(result, contains_exactly(expected_call_1))
 
     def test_list_call_log_ids(self):
         cel_1, cel_2 = Mock(call_log_id=1), Mock(call_log_id=1)

--- a/wazo_call_logd/tests/test_generator.py
+++ b/wazo_call_logd/tests/test_generator.py
@@ -55,7 +55,7 @@ class TestCallLogsGenerator(TestCase):
     def test_call_logs_from_cel_one_call(self, raw_call_log_constructor):
         linkedid = '9328742934'
         cels = self._generate_cel_for_call([linkedid])
-        call = Mock(recordings=[])
+        call = Mock(raw_participants={}, recordings=[])
         self.interpretor.interpret_cels.return_value = call
         raw_call_log_constructor.return_value = call
         expected_call = call.to_call_log.return_value
@@ -70,8 +70,8 @@ class TestCallLogsGenerator(TestCase):
         cels_1 = self._generate_cel_for_call('9328742934')
         cels_2 = self._generate_cel_for_call('2707230959')
         cels = cels_1 + cels_2
-        call_1 = Mock(recordings=[])
-        call_2 = Mock(recordings=[])
+        call_1 = Mock(raw_participants={}, recordings=[])
+        call_2 = Mock(raw_participants={}, recordings=[])
         self.interpretor.interpret_cels.side_effect = [call_1, call_2]
         raw_call_log_constructor.side_effect = [call_1, call_2]
         expected_call_1 = call_1.to_call_log.return_value
@@ -90,8 +90,8 @@ class TestCallLogsGenerator(TestCase):
         cels_1 = self._generate_cel_for_call('9328742934')
         cels_2 = self._generate_cel_for_call('2707230959')
         cels = cels_1 + cels_2
-        call_1 = Mock(recordings=[])
-        call_2 = Mock(recordings=[])
+        call_1 = Mock(raw_participants={}, recordings=[])
+        call_2 = Mock(raw_participants={}, recordings=[])
         self.interpretor.interpret_cels.side_effect = [call_1, call_2]
         raw_call_log_constructor.side_effect = [call_1, call_2]
         expected_call_1 = call_1.to_call_log.return_value
@@ -119,8 +119,12 @@ class TestCallLogsGenerator(TestCase):
         interpretor_true_1.can_interpret.return_value = True
         interpretor_true_2.can_interpret.return_value = True
         interpretor_false.can_interpret.return_value = False
-        interpretor_true_1.interpret_cels.return_value = Mock(recordings=[])
-        interpretor_true_2.interpret_cels.return_value = Mock(recordings=[])
+        interpretor_true_1.interpret_cels.return_value = Mock(
+            raw_participants={}, recordings=[]
+        )
+        interpretor_true_2.interpret_cels.return_value = Mock(
+            raw_participants={}, recordings=[]
+        )
         generator = CallLogsGenerator(
             self.confd_client,
             [

--- a/wazo_call_logd/tests/test_participant.py
+++ b/wazo_call_logd/tests/test_participant.py
@@ -1,0 +1,71 @@
+# Copyright 2013-2021 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from hamcrest import (
+    assert_that,
+    has_entries,
+    none,
+)
+from mock import Mock
+from unittest import TestCase
+
+from ..participant import find_participant
+
+
+def confd_mock(lines=None):
+    lines = lines or []
+    confd = Mock()
+    confd.lines.list.return_value = {'items': lines}
+    confd.users.get.return_value = (
+        lines[0]['users'][0] if lines and lines[0].get('users') else None
+    )
+    return confd
+
+
+class TestFindParticipant(TestCase):
+    def test_find_participants_when_channame_is_not_parsable(self):
+        confd = confd_mock()
+        channame = 'something'
+
+        result = find_participant(confd, channame)
+
+        assert_that(result, none())
+
+    def test_find_participants_when_no_lines(self):
+        confd = confd_mock()
+        channame = 'sip/something-suffix'
+
+        result = find_participant(confd, channame)
+
+        assert_that(result, none())
+
+    def test_find_participants_when_line_has_no_user(self):
+        lines = [{'id': 12, 'users': []}]
+        confd = confd_mock(lines)
+        channame = 'sip/something-suffix'
+
+        result = find_participant(confd, channame)
+
+        assert_that(result, none())
+
+    def test_find_participants_when_line_has_user(self):
+        user = {
+            'uuid': 'user_uuid',
+            'tenant_uuid': 'tenant_uuid',
+            'userfield': 'user_userfield, toto',
+        }
+        lines = [{'id': 12, 'users': [user], 'extensions': []}]
+        confd = confd_mock(lines)
+        channame = 'sip/something-suffix'
+
+        result = find_participant(confd, channame)
+
+        assert_that(
+            result,
+            has_entries(
+                uuid='user_uuid',
+                tenant_uuid='tenant_uuid',
+                line_id=12,
+                tags=['user_userfield', 'toto'],
+            ),
+        )


### PR DESCRIPTION
## call_log: extract find_participant to its own module

Why:

* Will not be used by cel_interpretor anymore

## call_log generation: fetch participants at the end

Why:

* Easier to detect duplicate participants

## call log generation: remove duplicate participants

Why:

* When calling a group and waiting for a long time, group members
appear as duplicate participants.