### PR TITLE
Zuul migration

### DIFF
--- a/zuul.yaml
+++ b/zuul.yaml
@@ -5,12 +5,10 @@
       - debian-packaging-template
     check:
       jobs:
-        - wazo-tox-integration-call-logd:
-            nodeset: vm-debian-10-m1s
+        - wazo-tox-integration-call-logd
     gate:
       jobs:
-        - wazo-tox-integration-call-logd:
-            nodeset: vm-debian-10-m1s
+        - wazo-tox-integration-call-logd
 
 - job:
     name: wazo-tox-integration-call-logd

--- a/zuul.yaml
+++ b/zuul.yaml
@@ -16,8 +16,8 @@
     check:
       jobs:
         - wazo-tox-integration-call-logd:
-            nodeset: debian10-vm
+            nodeset: vm-debian-10-m1s
     gate:
       jobs:
         - wazo-tox-integration-call-logd:
-            nodeset: debian10-vm
+            nodeset: vm-debian-10-m1s

--- a/zuul.yaml
+++ b/zuul.yaml
@@ -1,13 +1,3 @@
-- job:
-    name: wazo-tox-integration-call-logd
-    parent: wazo-tox-integration
-    required-projects:
-      wazo-platform/xivo-manage-db
-    timeout: 3600
-    vars:
-      docker_compose_services_override:
-        - call-logd
-
 - project:
     templates:
       - wazo-tox-py37
@@ -21,3 +11,13 @@
       jobs:
         - wazo-tox-integration-call-logd:
             nodeset: vm-debian-10-m1s
+
+- job:
+    name: wazo-tox-integration-call-logd
+    parent: wazo-tox-integration
+    required-projects:
+      wazo-platform/xivo-manage-db
+    timeout: 3600
+    vars:
+      docker_compose_services_override:
+        - call-logd


### PR DESCRIPTION
## Zuul migration


## Fix definition order, otherwise 'Job wazo-tox-integration-call-logd not defined'
