### PR TITLE
test: use explicit ipv4 addr to connect docker

### DIFF
--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -52,8 +52,8 @@ from .filesystem import FileSystemClient
 urllib3.disable_warnings()
 logger = logging.getLogger(__name__)
 
-CEL_DB_URI = os.getenv('DB_URI', 'postgresql://asterisk:proformatique@localhost:{port}')
-DB_URI = os.getenv('DB_URI', 'postgresql://wazo-call-logd:Secr7t@localhost:{port}')
+CEL_DB_URI = os.getenv('DB_URI', 'postgresql://asterisk:proformatique@127.0.0.1:{port}')
+DB_URI = os.getenv('DB_URI', 'postgresql://wazo-call-logd:Secr7t@127.0.0.1:{port}')
 
 
 # this decorator takes the output of a psql and changes it into a list of dict
@@ -151,7 +151,7 @@ class _BaseIntegrationTest(AssetLaunchingTestCase):
             return WrongClient(name='call-logd')
 
         return CallLogdClient(
-            'localhost',
+            '127.0.0.1',
             port,
             prefix=None,
             https=False,
@@ -165,7 +165,7 @@ class _BaseIntegrationTest(AssetLaunchingTestCase):
         except (NoSuchService, NoSuchPort):
             return WrongClient(name='auth')
 
-        return AuthClient('localhost', port)
+        return AuthClient('127.0.0.1', port)
 
     @classmethod
     def make_database(cls):
@@ -177,7 +177,7 @@ class _BaseIntegrationTest(AssetLaunchingTestCase):
         return DbHelper.build(
             'wazo-call-logd',
             'Secr7t',
-            'localhost',
+            '127.0.0.1',
             port,
             'wazo-call-logd',
         )
@@ -192,7 +192,7 @@ class _BaseIntegrationTest(AssetLaunchingTestCase):
         return DbHelper.build(
             'asterisk',
             'proformatique',
-            'localhost',
+            '127.0.0.1',
             port,
             'asterisk',
         )
@@ -205,7 +205,7 @@ class _BaseIntegrationTest(AssetLaunchingTestCase):
 
     @classmethod
     def make_confd(cls):
-        return ConfdClient('localhost', cls.service_port(9486, 'confd'))
+        return ConfdClient('127.0.0.1', cls.service_port(9486, 'confd'))
 
     @classmethod
     def make_filesystem(cls):

--- a/integration_tests/suite/test_cdr_recording.py
+++ b/integration_tests/suite/test_cdr_recording.py
@@ -141,7 +141,7 @@ class TestRecording(IntegrationTest):
         self.filesystem.create_file('/tmp/foobar.wav', content='my-recording-content')
         recording_uuid = self.call_logd.cdr.get_by_id(cdr_id)['recordings'][0]['uuid']
         port = self.service_port(9298, 'call-logd')
-        base_url = f'http://localhost:{port}/1.0'
+        base_url = f'http://127.0.0.1:{port}/1.0'
         api_url = f'{base_url}/cdr/{cdr_id}/recordings/{recording_uuid}/media'
 
         params = {'tenant': MAIN_TENANT, 'token': MAIN_TOKEN}

--- a/integration_tests/suite/test_documentation.py
+++ b/integration_tests/suite/test_documentation.py
@@ -16,6 +16,6 @@ logger.setLevel(logging.INFO)
 class TestDocumentation(IntegrationTest):
     def test_documentation_errors(self):
         port = self.service_port(9298, 'call-logd')
-        api_url = 'http://localhost:{port}/1.0/api/api.yml'.format(port=port)
+        api_url = 'http://127.0.0.1:{port}/1.0/api/api.yml'.format(port=port)
         api = requests.get(api_url)
         validate_v2_spec(yaml.safe_load(api.text))


### PR DESCRIPTION
reason: service_port() returns only port bound to ipv4. Some host can
resolve localhost to ipv6 address and docker doesn't necessarily bind
the same port number on ipv4 and ipv6