### PR TITLE
add the content-disposition header on csv exports

### DIFF
--- a/integration_tests/suite/test_cdr.py
+++ b/integration_tests/suite/test_cdr.py
@@ -1700,3 +1700,15 @@ class TestListCDR(IntegrationTest):
             response.json()['items'],
             contains_exactly(has_entries(tenant_uuid=MASTER_TENANT)),
         )
+
+    def test_list_csv_export_adds_the_content_disposition_header(self):
+        port = self.service_port(9298, 'call-logd')
+
+        response = requests.get(
+            f'http://localhost:{port}/1.0/users/me/cdr',
+            params={'format': 'csv', 'token': USER_1_TOKEN},
+        )
+        assert_that(
+            response.headers,
+            has_entries('Content-Disposition', 'attachment; filename=cdr.csv'),
+        )

--- a/wazo_call_logd/plugins/cdr/http.py
+++ b/wazo_call_logd/plugins/cdr/http.py
@@ -100,7 +100,10 @@ def _output_csv(data, code, http_headers=None):
         for csv_line in csv_body:
             writer.writerow(csv_line)
 
-        response = make_response(csv_text.getvalue())
+        response = make_response(
+            csv_text.getvalue(),
+            {'Content-Disposition': 'attachment; filename=cdr.csv'},
+        )
     else:
         raise NotImplementedError('No known CSV representation')
 


### PR DESCRIPTION
signal to the browser that the result should be downloaded