### PR TITLE
cdr export: generate the filename based on the content

### DIFF
--- a/integration_tests/suite/test_cdr.py
+++ b/integration_tests/suite/test_cdr.py
@@ -20,6 +20,7 @@ from hamcrest import (
     has_key,
     has_length,
     has_properties,
+    starts_with,
 )
 from wazo_call_logd_client.exceptions import CallLogdError
 from xivo_test_helpers.auth import MockUserToken
@@ -1710,5 +1711,7 @@ class TestListCDR(IntegrationTest):
         )
         assert_that(
             response.headers,
-            has_entries('Content-Disposition', 'attachment; filename=cdr.csv'),
+            has_entries(
+                'Content-Disposition', starts_with('attachment; filename=cdr-')
+            ),
         )

--- a/wazo_call_logd/plugins/cdr/http.py
+++ b/wazo_call_logd/plugins/cdr/http.py
@@ -3,6 +3,7 @@
 
 import logging
 import csv
+import hashlib
 
 from io import StringIO
 
@@ -100,9 +101,13 @@ def _output_csv(data, code, http_headers=None):
         for csv_line in csv_body:
             writer.writerow(csv_line)
 
+        response_body = csv_text.getvalue()
+        hash_ = hashlib.sha1()
+        hash_.update(response_body.encode())
+        sha1sum = hash_.hexdigest()
         response = make_response(
             csv_text.getvalue(),
-            {'Content-Disposition': 'attachment; filename=cdr.csv'},
+            {'Content-Disposition': f'attachment; filename=cdr-{sha1sum}.csv'},
         )
     else:
         raise NotImplementedError('No known CSV representation')


### PR DESCRIPTION
this avoids caching issue on the client side that happenned when the file was
always named cdr.csv