### PR TITLE
set pg application_name

### DIFF
--- a/etc/wazo-call-logd/config.yml
+++ b/etc/wazo-call-logd/config.yml
@@ -10,8 +10,8 @@ extra_config_files: /etc/wazo-call-logd/conf.d/
 debug: false
 
 # Database connection informations.
-db_uri: postgresql://asterisk:proformatique@localhost/asterisk
-cel_db_uri: postgresql://asterisk:proformatique@localhost/asterisk
+db_uri: postgresql://asterisk:proformatique@localhost/asterisk?application_name=wazo-call-logd
+cel_db_uri: postgresql://asterisk:proformatique@localhost/asterisk?application_name=wazo-call-logd
 
 # Event bus (AMQP) connection informations
 bus:

--- a/wazo_call_logd/config.py
+++ b/wazo_call_logd/config.py
@@ -19,8 +19,8 @@ DEFAULT_CONFIG = {
     'debug': False,
     'user': 'wazo-call-logd',
     'db_upgrade_on_startup': False,
-    'db_uri': 'postgresql://asterisk:proformatique@localhost/asterisk',
-    'cel_db_uri': 'postgresql://asterisk:proformatique@localhost/asterisk',
+    'db_uri': 'postgresql://asterisk:proformatique@localhost/asterisk?application_name=wazo-call-logd',
+    'cel_db_uri': 'postgresql://asterisk:proformatique@localhost/asterisk?application_name=wazo-call-logd',
     'email_export_body_template': '/var/lib/wazo-call-logd/templates/email_export_body.j2',
     'email_export_token_expiration': 48 * 3600,  # 48 hours
     'email_export_from_name': 'Wazo',


### PR DESCRIPTION
why: used for traceability
replace: https://github.com/wazo-platform/xivo-dao/pull/23