### PR TITLE
cdr: add the source_internal_name field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 21.10
+
+* The `/cdr` resource now includes the `source_internal_name` field
+
 ## 21.08
 
 * The `/retention` resource now includes:

--- a/integration_tests/suite/test_call_log_generation.py
+++ b/integration_tests/suite/test_call_log_generation.py
@@ -758,6 +758,39 @@ LINKEDID_END | 2015-06-18 14:09:02.272325 | SIP/as2mkq-0000001f | 1434650936.31 
 
     @raw_cels(
         '''\
+    eventtype     |           eventtime           |   cid_name   |  cid_num   |   exten    |   context   |                                channame                                |   uniqueid   |   linkedid
+
+ CHAN_START       | 2021-07-19 11:12:54.23216-04  | Olga Romanov | 1015       | 5551112222 | inside      | PJSIP/ru3fqt3x-00000007                                                | 1626707574.7 | 1626707574.7
+ MIXMONITOR_START | 2021-07-19 11:12:54.764512-04 | O Romanov    | 5550001234 | s          | outcall     | PJSIP/ru3fqt3x-00000007                                                | 1626707574.7 | 1626707574.7
+ XIVO_OUTCALL     | 2021-07-19 11:12:54.776572-04 | O Romanov    | 5550001234 | dial       | outcall     | PJSIP/ru3fqt3x-00000007                                                | 1626707574.7 | 1626707574.7
+ APP_START        | 2021-07-19 11:12:54.805195-04 | O Romanov    | 5550001234 | dial       | outcall     | PJSIP/ru3fqt3x-00000007                                                | 1626707574.7 | 1626707574.7
+ CHAN_START       | 2021-07-19 11:12:54.806786-04 | wazo         |            | s          | from-extern | PJSIP/voipms_trunk_2c34c282-433e-4bb8-8d56-fec14ff7e1e9_39756-00000008 | 1626707574.8 | 1626707574.7
+ ANSWER           | 2021-07-19 11:13:04.25334-04  |              | 5551112222 | dial       | from-extern | PJSIP/voipms_trunk_2c34c282-433e-4bb8-8d56-fec14ff7e1e9_39756-00000008 | 1626707574.8 | 1626707574.7
+ ANSWER           | 2021-07-19 11:13:04.254462-04 | O Romanov    | 5550001234 | dial       | outcall     | PJSIP/ru3fqt3x-00000007                                                | 1626707574.7 | 1626707574.7
+ BRIDGE_ENTER     | 2021-07-19 11:13:04.258807-04 |              | 5551112222 |            | from-extern | PJSIP/voipms_trunk_2c34c282-433e-4bb8-8d56-fec14ff7e1e9_39756-00000008 | 1626707574.8 | 1626707574.7
+ BRIDGE_ENTER     | 2021-07-19 11:13:04.259302-04 | O Romanov    | 5550001234 | dial       | outcall     | PJSIP/ru3fqt3x-00000007                                                | 1626707574.7 | 1626707574.7
+ BRIDGE_EXIT      | 2021-07-19 11:13:06.99904-04  |              | 5551112222 |            | from-extern | PJSIP/voipms_trunk_2c34c282-433e-4bb8-8d56-fec14ff7e1e9_39756-00000008 | 1626707574.8 | 1626707574.7
+ BRIDGE_EXIT      | 2021-07-19 11:13:07.000866-04 | O Romanov    | 5550001234 | dial       | outcall     | PJSIP/ru3fqt3x-00000007                                                | 1626707574.7 | 1626707574.7
+ HANGUP           | 2021-07-19 11:13:07.002422-04 |              | 5551112222 |            | from-extern | PJSIP/voipms_trunk_2c34c282-433e-4bb8-8d56-fec14ff7e1e9_39756-00000008 | 1626707574.8 | 1626707574.7
+ CHAN_END         | 2021-07-19 11:13:07.002422-04 |              | 5551112222 |            | from-extern | PJSIP/voipms_trunk_2c34c282-433e-4bb8-8d56-fec14ff7e1e9_39756-00000008 | 1626707574.8 | 1626707574.7
+ HANGUP           | 2021-07-19 11:13:07.00682-04  | O Romanov    | 5550001234 | dial       | outcall     | PJSIP/ru3fqt3x-00000007                                                | 1626707574.7 | 1626707574.7
+ CHAN_END         | 2021-07-19 11:13:07.00682-04  | O Romanov    | 5550001234 | dial       | outcall     | PJSIP/ru3fqt3x-00000007                                                | 1626707574.7 | 1626707574.7
+ LINKEDID_END     | 2021-07-19 11:13:07.00682-04  | O Romanov    | 5550001234 | dial       | outcall     | PJSIP/ru3fqt3x-00000007                                                | 1626707574.7 | 1626707574.7
+        '''
+    )
+    def test_answered_outgoing_call_with_custom_caller_id(self):
+        self._assert_last_call_log_matches(
+            '1626707574.7',
+            has_properties(
+                source_name='O Romanov',
+                source_exten='5550001234',
+                source_internal_name='Olga Romanov',
+                requested_exten='5551112222',
+            ),
+        )
+
+    @raw_cels(
+        '''\
  eventtype    | eventtime                  | cid_name | cid_num   | exten     | context     | channame              |      uniqueid |     linkedid  | userfield
 
  CHAN_START   | 2015-06-18 14:13:18.176182 | Elès 01  | 1001      | **9642301 | default     | SIP/je5qtq-00000027   | 1434651198.39 | 1434651198.39 |

--- a/integration_tests/suite/test_cdr.py
+++ b/integration_tests/suite/test_cdr.py
@@ -394,6 +394,7 @@ class TestListCDR(IntegrationTest):
         direction='outbound',
         source_exten='7867',
         source_name='.rùos',
+        source_internal_name='FôoBàr'
     )
     def test_given_call_logs_when_list_cdr_then_list_cdr(self):
         result = self.call_logd.cdr.list()
@@ -438,6 +439,7 @@ class TestListCDR(IntegrationTest):
                         call_direction='outbound',
                         source_extension='7867',
                         source_name='.rùos',
+                        source_internal_name='FôoBàr',
                         tags=[],
                         recordings=[],
                     ),

--- a/integration_tests/suite/test_cdr.py
+++ b/integration_tests/suite/test_cdr.py
@@ -394,7 +394,7 @@ class TestListCDR(IntegrationTest):
         direction='outbound',
         source_exten='7867',
         source_name='.rùos',
-        source_internal_name='FôoBàr'
+        source_internal_name='FôoBàr',
     )
     def test_given_call_logs_when_list_cdr_then_list_cdr(self):
         result = self.call_logd.cdr.list()

--- a/wazo_call_logd/cel_interpretor.py
+++ b/wazo_call_logd/cel_interpretor.py
@@ -122,6 +122,7 @@ class CallerCELInterpretor(AbstractCELInterpretor):
     def interpret_chan_start(self, cel, call):
         call.date = cel.eventtime
         call.source_name = cel.cid_name
+        call.source_internal_name = cel.cid_name
         call.source_exten = cel.cid_num
         call.requested_exten = cel.exten if cel.exten != 's' else ''
         call.requested_context = cel.context

--- a/wazo_call_logd/database/alembic/versions/4e193f4c53d0_add_the_source_internal_name_column.py
+++ b/wazo_call_logd/database/alembic/versions/4e193f4c53d0_add_the_source_internal_name_column.py
@@ -1,0 +1,24 @@
+"""add the source_internal_name column
+
+Revision ID: 4e193f4c53d0
+Revises: 48427e863c39
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '4e193f4c53d0'
+down_revision = '48427e863c39'
+
+TABLE_NAME = 'call_logd_call_log'
+COLUMN_NAME = 'source_internal_name'
+
+
+def upgrade():
+    op.add_column(TABLE_NAME, sa.Column(COLUMN_NAME, sa.Text))
+
+
+def downgrade():
+    op.drop_column(TABLE_NAME, COLUMN_NAME)

--- a/wazo_call_logd/database/models.py
+++ b/wazo_call_logd/database/models.py
@@ -48,6 +48,7 @@ class CallLog(Base):
     )
     source_name = Column(String(255))
     source_exten = Column(String(255))
+    source_internal_name = Column(Text)
     source_internal_exten = Column(Text)
     source_internal_context = Column(Text)
     source_line_identity = Column(String(255))

--- a/wazo_call_logd/plugins/cdr/http.py
+++ b/wazo_call_logd/plugins/cdr/http.py
@@ -59,6 +59,7 @@ CSV_HEADERS = [
     'requested_internal_context',
     'source_extension',
     'source_name',
+    'source_internal_name',
     'source_internal_extension',
     'source_internal_context',
     'source_user_uuid',

--- a/wazo_call_logd/plugins/cdr/schemas.py
+++ b/wazo_call_logd/plugins/cdr/schemas.py
@@ -85,6 +85,7 @@ class CDRSchema(Schema):
     requested_internal_extension = fields.String(attribute='requested_internal_exten')
     source_extension = fields.String(attribute='source_exten')
     source_internal_context = fields.String()
+    source_internal_name = fields.String()
     source_internal_extension = fields.String(attribute='source_internal_exten')
     source_line_id = fields.Integer()
     source_name = fields.String()

--- a/wazo_call_logd/raw_call_log.py
+++ b/wazo_call_logd/raw_call_log.py
@@ -19,6 +19,7 @@ class RawCallLog:
         self.source_exten = None
         self.source_internal_exten = None
         self.source_internal_context = None
+        self.source_internal_name = None
         self.requested_name = None
         self.requested_exten = None
         self.requested_context = None
@@ -71,6 +72,7 @@ class RawCallLog:
             source_exten=self.source_exten,
             source_internal_exten=self.source_internal_exten,
             source_internal_context=self.source_internal_context,
+            source_internal_name=self.source_internal_name,
             requested_exten=self.requested_exten,
             requested_context=self.requested_context,
             requested_internal_exten=self.requested_internal_exten,


### PR DESCRIPTION
this allows not to loose the caller's name when the external caller is
customized. This is useful if the outgoing caller is set to a general name and
number for the whole tenant