### PR TITLE
Wazo-2638: Migration of wazo-agentd from Marshmallow 3.0.0b14 to stable version 3.10.0

### DIFF
--- a/integration_tests/test-requirements-for-tox.txt
+++ b/integration_tests/test-requirements-for-tox.txt
@@ -2,7 +2,7 @@ https://github.com/wazo-platform/wazo-lib-rest-client/archive/master.zip
 https://github.com/wazo-platform/wazo-call-logd-client/archive/master.zip
 https://github.com/wazo-platform/wazo-test-helpers/archive/master.zip
 kombu
-marshmallow==3.0.0b14
+marshmallow==3.10.0
 mock
 openapi-spec-validator
 pyhamcrest

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ flask==1.0.2
 itsdangerous==0.24  # from flask
 jsonpatch==1.21
 kombu==4.6.11
-marshmallow==3.0.0b14
+marshmallow==3.10.0
 psycopg2==2.7.7
 python-dateutil==2.7.3  # from marshmallow, to accept more date formats
 pytz==2019.1

--- a/wazo_call_logd/plugins/cdr/schemas.py
+++ b/wazo_call_logd/plugins/cdr/schemas.py
@@ -40,7 +40,7 @@ class CDRListingBase(Schema):
     recurse = fields.Boolean(missing=False)
 
     @pre_load
-    def convert_tags_and_user_uuid_to_list(self, data):
+    def convert_tags_and_user_uuid_to_list(self, data, **kwargs):
         result = data.to_dict()
         if data.get('tags'):
             result['tags'] = data['tags'].split(',')
@@ -94,20 +94,20 @@ class CDRSchema(Schema):
     recordings = fields.Nested('RecordingSchema', many=True, default=[])
 
     @pre_dump
-    def _compute_fields(self, data):
+    def _compute_fields(self, data, **kwargs):
         data.marshmallow_answered = True if data.date_answer else False
         if data.date_answer and data.date_end:
             data.marshmallow_duration = data.date_end - data.date_answer
         return data
 
     @post_dump
-    def fix_negative_duration(self, data):
+    def fix_negative_duration(self, data, **kwargs):
         if data['duration'] is not None:
             data['duration'] = max(data['duration'], 0)
         return data
 
     @pre_dump
-    def _populate_tags_field(self, data):
+    def _populate_tags_field(self, data, **kwargs):
         data.marshmallow_tags = set()
         for participant in data.participants:
             data.marshmallow_tags.update(participant.tags)
@@ -127,7 +127,7 @@ class CDRListRequestSchema(CDRListingBase):
     format = fields.String(validate=OneOf(['csv', 'json']), missing=None)
 
     @post_load
-    def map_order_field(self, in_data):
+    def map_order_field(self, in_data, **kwargs):
         mapped_order = CDRSchema().fields[in_data['order']].attribute
         if mapped_order:
             in_data['order'] = mapped_order

--- a/wazo_call_logd/plugins/retention/schemas.py
+++ b/wazo_call_logd/plugins/retention/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from marshmallow import validates_schema
@@ -28,5 +28,5 @@ class RetentionSchema(Schema):
         if recording_days > cdr_days:
             raise ValidationError(
                 '"recording_days" must be higher or equal than "cdr_days"',
-                'recording_days',
+                field_name='recording_days',
             )

--- a/wazo_call_logd/plugins/retention/schemas.py
+++ b/wazo_call_logd/plugins/retention/schemas.py
@@ -19,7 +19,7 @@ class RetentionSchema(Schema):
     default_recording_days = fields.Integer(dump_only=True)
 
     @validates_schema
-    def validate_days(self, data):
+    def validate_days(self, data, **kwargs):
         cdr_days = data.get('cdr_days')
         recording_days = data.get('recording_days')
         if cdr_days is None or recording_days is None:

--- a/wazo_call_logd/plugins/support_center/schemas.py
+++ b/wazo_call_logd/plugins/support_center/schemas.py
@@ -95,7 +95,7 @@ class _StatisticsListRequestSchema(Schema):
             return timezone.normalize(utc_dt)
 
     @pre_load
-    def convert_week_days_to_list(self, data):
+    def convert_week_days_to_list(self, data, **kwargs):
         result = data.copy()
         if not isinstance(data, dict):
             result = data.to_dict()
@@ -166,7 +166,7 @@ class QueueStatisticsQoSRequestSchema(_StatisticsListRequestSchema):
     qos_thresholds = fields.List(fields.Integer(validate=Range(min=0)), missing=[])
 
     @pre_load
-    def convert_qos_thresholds_to_list(self, data):
+    def convert_qos_thresholds_to_list(self, data, **kwargs):
         result = data.copy()
         if not isinstance(result, dict):
             result = result.to_dict()
@@ -175,7 +175,7 @@ class QueueStatisticsQoSRequestSchema(_StatisticsListRequestSchema):
         return result
 
     @post_load
-    def sort_qos_thresholds(self, data):
+    def sort_qos_thresholds(self, data, **kwargs):
         result = data.copy()
         if data.get('qos_thresholds'):
             result['qos_thresholds'] = sorted(data['qos_thresholds'])


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/xivo-lib-python/pull/93