### PR TITLE
tests: wait for everything is up before using API

### DIFF
--- a/integration_tests/suite/test_export.py
+++ b/integration_tests/suite/test_export.py
@@ -31,6 +31,7 @@ from .helpers.constants import (
     USER_2_UUID,
 )
 from .helpers.database import call_log, export, recording
+from .helpers.wait_strategy import CallLogdEverythingUpWaitStrategy
 
 
 class TestExportAPI(IntegrationTest):
@@ -145,6 +146,7 @@ class TestExportAPI(IntegrationTest):
 class TestRecordingMediaExport(IntegrationTest):
 
     asset = 'base'
+    wait_strategy = CallLogdEverythingUpWaitStrategy()
 
     def _recording_filename(self, rec):
         start = rec['start_time'].strftime('%Y-%m-%dT%H_%M_%SUTC')


### PR DESCRIPTION
why: recording export use celery which use rabbitmq. So if bus is not
ready, task can be triggered some time later

This fix is not perfect, because the bus_consumer:ok doesn't reflect the
celery connection to the bus. But it should mitigate some race condition