### PR TITLE
Pull request for WAZO-2693-pin-itsdangerous

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ cheroot==6.5.4
 flask==1.0.2
 flask-restful==0.3.7
 flask-cors==3.0.7
+itsdangerous==0.24  # from flask
 jsonpatch==1.21
 kombu==4.6.11
 marshmallow==3.0.0b14

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,9 @@ https://github.com/wazo-platform/wazo-lib-rest-client/archive/master.zip  # from
 alembic==1.0.0
 celery==4.4.6
 cheroot==6.5.4
-flask==1.0.2
-flask-restful==0.3.7
 flask-cors==3.0.7
+flask-restful==0.3.7
+flask==1.0.2
 itsdangerous==0.24  # from flask
 jsonpatch==1.21
 kombu==4.6.11


### PR DESCRIPTION
## pin itsdangerous version

why: if not pinned, pip install latest version (2.1.0) which is
incompatible with flask 1.0.2 from buster

## sort requirements.txt