### PR TITLE
integration tests: handle running tests near midnight

### DIFF
--- a/integration_tests/suite/test_agent_stats.py
+++ b/integration_tests/suite/test_agent_stats.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytz
@@ -202,11 +202,10 @@ class TestInputParameters(IntegrationTest):
 class TestStatistics(IntegrationTest):
     def _get_tomorrow(self, timezone=None):
         timezone = timezone or pytz.utc
-        today = timezone.normalize(timezone.localize(datetime.now()))
+        today = datetime.now(pytz.utc).astimezone(timezone)
         return timezone.normalize(
-            timezone.localize(
-                datetime(today.year, today.month, today.day) + relativedelta(days=1)
-            )
+            timezone.localize(datetime(today.year, today.month, today.day))
+            + relativedelta(days=1)
         ).isoformat(timespec='seconds')
 
     def test_list_agent_statistics_when_no_stats(self):


### PR DESCRIPTION
Why:

* when running the tests at 23:56 local time, computation of tomorrow is
wrong when using UTC timezone