### PR TITLE
status: add celery status

### DIFF
--- a/integration_tests/suite/test_status.py
+++ b/integration_tests/suite/test_status.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, equal_to, has_entries, has_entry
@@ -15,6 +15,7 @@ class TestStatusNoRabbitMQ(IntegrationTest):
         result = self.call_logd.status.get()
 
         assert_that(result['bus_consumer']['status'], equal_to('fail'))
+        assert_that(result['task_queue']['status'], equal_to('fail'))
 
 
 class TestStatusRabbitMQStops(IntegrationTest):
@@ -29,6 +30,7 @@ class TestStatusRabbitMQStops(IntegrationTest):
         def rabbitmq_is_down():
             result = self.call_logd.status.get()
             assert_that(result['bus_consumer']['status'], equal_to('fail'))
+            assert_that(result['task_queue']['status'], equal_to('fail'))
 
         until.assert_(rabbitmq_is_down, timeout=5)
 
@@ -46,6 +48,7 @@ class TestStatusAllOK(IntegrationTest):
                 result,
                 has_entries(
                     bus_consumer=has_entry('status', 'ok'),
+                    task_queue=has_entry('status', 'ok'),
                     service_token=has_entry('status', 'ok'),
                 ),
             )

--- a/wazo_call_logd/controller.py
+++ b/wazo_call_logd/controller.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -100,6 +100,7 @@ class Controller:
         )
         self.status_aggregator.add_provider(self.bus_client.provide_status)
         self.status_aggregator.add_provider(self.token_status.provide_status)
+        self.status_aggregator.add_provider(celery.provide_status)
         signal.signal(signal.SIGTERM, partial(_sigterm_handler, self))
 
         self._update_db_from_config_file()

--- a/wazo_call_logd/plugins/status/api.yml
+++ b/wazo_call_logd/plugins/status/api.yml
@@ -16,6 +16,8 @@ definitions:
     properties:
       bus_consumer:
         $ref: '#/definitions/ComponentWithStatus'
+      task_queue:
+        $ref: '#/definitions/ComponentWithStatus'
       service_token:
         $ref: '#/definitions/ComponentWithStatus'
   ComponentWithStatus:


### PR DESCRIPTION
Why:

* Some tests need Celery to be connected before starting

How:

* I could not find a clean way to know if the Celery app is connected to
its broker: the app connects lazily to the broker, and in the status
tests, no connection has been made yet.
* The status tries to establish a connection itself