### PR TITLE
Make sure XIVO_UUID environment variable is in cron job

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wazo-call-logd (22.06~20220421) wazo-dev; urgency=medium
+
+  * Add XIVO_UUID to cron job
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Thu, 21 Apr 2022 10:18:03 -0400
+
 wazo-call-logd (17.15~20171011) wazo-dev; urgency=medium
 
   * Finalization of renaming {xivo,wazo}-call-logd

--- a/debian/cron.d
+++ b/debian/cron.d
@@ -2,4 +2,4 @@
 # cron jobs for wazo-call-logs
 #
 
-25 4 * * * root /usr/bin/wazo-call-logs
+25 4 * * * root . /etc/profile.d/xivo_uuid.sh; /usr/bin/wazo-call-logs

--- a/debian/cron.d
+++ b/debian/cron.d
@@ -2,4 +2,4 @@
 # cron jobs for wazo-call-logs
 #
 
-25 4 * * * root . /etc/profile.d/xivo_uuid.sh; /usr/bin/wazo-call-logs
+25 4 * * * root source /etc/profile.d/xivo_uuid.sh && /usr/bin/wazo-call-logs


### PR DESCRIPTION
Why:

* Cron loads minimal environment variables by default (HOME, SHELL, PWD)
* wazo-call-logs now depends on XIVO_UUID when sending bus message (non-null origin_uuid)