### PR TITLE
NES-1790-answered-rate-ignore-closed

### DIFF
--- a/integration_tests/suite/test_db_queue_stat.py
+++ b/integration_tests/suite/test_db_queue_stat.py
@@ -1,4 +1,4 @@
-# Copyright 2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from datetime import (
@@ -226,7 +226,7 @@ class TestQueueStat(DBIntegrationTest):
     def test_get_interval_return_specific_answered_rate(self):
         tenant_uuids = None
         result = self.dao.queue_stat.get_interval(tenant_uuids)
-        expected = round(100.0 * 1 / 7, 2)
+        expected = round(100.0 * 1 / 6, 2)  # Closed calls are not counted
         assert_that(result[0], has_entries(answered_rate=expected))
 
     @stat_queue_periodic({'time': '2020-10-01 14:00:00', 'leaveempty': 1})
@@ -324,7 +324,7 @@ class TestQueueStat(DBIntegrationTest):
                 divert_waittime=2,
                 timeout=2,
                 qos=50.0,
-                answered_rate=14.29,
+                answered_rate=16.67,
                 average_waiting_time=1.25,
                 blocking=4,
                 saturated=6,

--- a/integration_tests/suite/test_queue_stats.py
+++ b/integration_tests/suite/test_queue_stats.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytz
@@ -569,7 +569,7 @@ class TestStatistics(IntegrationTest):
 
     # fmt: off
     @stat_queue_periodic({'queue_id': 1, 'time': '2020-10-06 4:00:00', 'total': 1, 'answered': 1})
-    @stat_queue_periodic({'queue_id': 1, 'time': '2020-10-06 5:00:00', 'total': 36, 'closed': 1, 'abandoned': 2, 'joinempty': 3, 'leaveempty': 4, 'timeout': 5, 'divert_ca_ratio': 6, 'divert_waittime': 7, 'full': 8})
+    @stat_queue_periodic({'queue_id': 1, 'time': '2020-10-06 5:00:00', 'total': 36, 'closed': 1, 'abandoned': 3, 'joinempty': 3, 'leaveempty': 4, 'timeout': 5, 'divert_ca_ratio': 6, 'divert_waittime': 7, 'full': 8})
     @stat_queue_periodic({'queue_id': 1, 'time': '2020-10-06 23:00:00', 'total': 1, 'answered': 1})
     @stat_queue_periodic({'queue_id': 1, 'time': '2020-10-07 00:00:00', 'total': 1, 'answered': 1})
     # fmt: on
@@ -610,7 +610,7 @@ class TestStatistics(IntegrationTest):
                     queue_name='queue',
                     received=36,
                     answered=0,
-                    abandoned=2,
+                    abandoned=3,
                     closed=1,
                     not_answered=5,
                     saturated=6 + 7 + 8,
@@ -644,13 +644,13 @@ class TestStatistics(IntegrationTest):
                     queue_name='queue',
                     received=38,
                     answered=2,
-                    abandoned=2,
+                    abandoned=3,
                     closed=1,
                     not_answered=5,
                     saturated=6 + 7 + 8,
                     blocked=3 + 4,
                     average_waiting_time=0,
-                    answered_rate=8.0,
+                    answered_rate=8.0,  # closed are not included
                     quality_of_service=None,
                 ),
             ),

--- a/wazo_call_logd/database/queries/queue_stat.py
+++ b/wazo_call_logd/database/queries/queue_stat.py
@@ -1,4 +1,4 @@
-# Copyright 2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy import func, text
@@ -218,7 +218,6 @@ class QueueStatDAO(BaseDAO):
             + stats['leaveempty']
             + stats['joinempty']
             + stats['timeout']
-            + stats['closed']
         )
         answered_rate = None
         if answered_rate_total > 0:


### PR DESCRIPTION
Call center performance should not be impacted by calls during closed hours.

I changed the tests to keep nice numbers, without incrementing the abandonned
number of call the answered rate would be 8.33