### PR TITLE
test: use mock from unittest library

### DIFF
--- a/integration_tests/suite/test_db_cel.py
+++ b/integration_tests/suite/test_db_cel.py
@@ -1,7 +1,9 @@
-# Copyright 2013-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from datetime import timedelta as td
+from unittest.mock import Mock
+
 from hamcrest import (
     assert_that,
     contains_exactly,
@@ -10,7 +12,6 @@ from hamcrest import (
     has_property,
     has_properties,
 )
-from mock import Mock
 from xivo_dao.alchemy.cel import CEL
 
 from .helpers.base import DBIntegrationTest

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,2 @@
-mock
 pyhamcrest!=1.10.0  # Version 1.10.0 is broken
 pytest

--- a/wazo_call_logd/tests/test_cel_interpretor.py
+++ b/wazo_call_logd/tests/test_cel_interpretor.py
@@ -1,7 +1,8 @@
-# Copyright 2013-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
+from unittest.mock import Mock, sentinel
 
 from hamcrest import (
     assert_that,
@@ -11,7 +12,6 @@ from hamcrest import (
     none,
     same_instance,
 )
-from mock import Mock, sentinel
 
 from ..cel_interpretor import (
     AbstractCELInterpretor,

--- a/wazo_call_logd/tests/test_generator.py
+++ b/wazo_call_logd/tests/test_generator.py
@@ -1,7 +1,8 @@
-# Copyright 2013-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
+from unittest.mock import ANY, Mock, patch
 
 from hamcrest import all_of
 from hamcrest import assert_that
@@ -12,9 +13,6 @@ from hamcrest import equal_to
 from hamcrest import has_property
 from hamcrest import is_
 from hamcrest import raises
-from mock import ANY
-from mock import Mock
-from mock import patch
 
 from wazo_call_logd.generator import CallLogsGenerator
 from wazo_call_logd.exceptions import InvalidCallLogException

--- a/wazo_call_logd/tests/test_manager.py
+++ b/wazo_call_logd/tests/test_manager.py
@@ -2,8 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
-
-from mock import Mock
+from unittest.mock import Mock
 
 from wazo_call_logd.manager import CallLogsManager
 from wazo_call_logd.generator import CallLogsGenerator

--- a/wazo_call_logd/tests/test_participant.py
+++ b/wazo_call_logd/tests/test_participant.py
@@ -1,13 +1,14 @@
-# Copyright 2013-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from unittest import TestCase
+from unittest.mock import Mock
 
 from hamcrest import (
     assert_that,
     has_entries,
     none,
 )
-from mock import Mock
-from unittest import TestCase
 
 from ..participant import find_participant
 

--- a/wazo_call_logd/tests/test_raw_call_log.py
+++ b/wazo_call_logd/tests/test_raw_call_log.py
@@ -1,10 +1,10 @@
-# Copyright 2013-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
+from unittest.mock import Mock, patch
 
 from hamcrest import all_of, assert_that, equal_to, has_property
-from mock import Mock, patch
 
 from wazo_call_logd.raw_call_log import RawCallLog
 from wazo_call_logd.exceptions import InvalidCallLogException

--- a/wazo_call_logd/tests/test_writer.py
+++ b/wazo_call_logd/tests/test_writer.py
@@ -1,9 +1,8 @@
-# Copyright 2013-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
-
-from mock import Mock
+from unittest.mock import Mock
 
 from wazo_call_logd.generator import CallLogsCreation
 from wazo_call_logd.writer import CallLogsWriter


### PR DESCRIPTION
why: pypi version is a backport if the python3 builtin package