### PR TITLE
adapt tox.ini for tox4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 envlist = py37, pycodestyle, pylint
-skipsdist = true
+skipsdist = false
 
 [testenv]
 basepython = python3.7
@@ -22,7 +22,7 @@ commands =
     -sh -c 'pycodestyle --ignore=E501 wazo_call_logd > pycodestyle.txt'
 deps =
     pycodestyle
-whitelist_externals =
+allowlist_externals =
     sh
 
 [testenv:pylint]
@@ -32,7 +32,7 @@ deps =
     -rrequirements.txt
     -rtest-requirements.txt
     pylint
-whitelist_externals =
+allowlist_externals =
     sh
 
 [testenv:black]
@@ -51,7 +51,7 @@ commands =
     flake8
 
 [testenv:integration]
-usedevelop = true
+use_develop = true
 deps = -rintegration_tests/test-requirements-for-tox.txt
 changedir = integration_tests
 passenv =
@@ -63,7 +63,7 @@ commands =
     make test-setup
     make cel-db
     pytest -v {posargs}
-whitelist_externals =
+allowlist_externals =
     make
     sh
 


### PR DESCRIPTION
Why:

* skipsdist and usedevelop are now mutually exclusive
* usedevelop -> use_develop for future
* whitelist_externals -> allowlist_externals