### PR TITLE
generator: use debug logger instead of info

### DIFF
--- a/wazo_call_logd/generator.py
+++ b/wazo_call_logd/generator.py
@@ -103,7 +103,7 @@ class _ParticipantsProcessor:
                 for p in call_log.participants_info
                 if "user_uuid" in p and p["user_uuid"] == user_uuid
             ]
-            logger.info(
+            logger.debug(
                 "Identified user participant %s(from CEL: %d, from channels: %d)",
                 user_uuid,
                 len(user_participants_info),


### PR DESCRIPTION
Why: too much noise in the logs.