### PR TITLE
Remove custom OrderedDefaultDict class as defaultdicts are ordered already

### DIFF
--- a/wazo_call_logd/raw_call_log.py
+++ b/wazo_call_logd/raw_call_log.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import logging
+from collections import defaultdict
 from datetime import datetime
-from typing import Literal
+from typing import DefaultDict, Literal
 
 from wazo_call_logd.database.models import CallLog, CallLogParticipant
 from wazo_call_logd.exceptions import InvalidCallLogException
 from wazo_call_logd.extension_filter import DEFAULT_HIDDEN_EXTENSIONS, ExtensionFilter
-from wazo_call_logd.utils import OrderedDefaultDict
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +37,7 @@ class RawCallLog:
         self.date_answer: datetime | None = None
         self.source_line_identity: str | None = None
         self.direction: Literal['source', 'destination', 'internal'] = 'internal'
-        self.raw_participants: dict[str, dict] = OrderedDefaultDict(default=dict)
+        self.raw_participants: DefaultDict[str, dict] = defaultdict(dict)
         self.participants_info: list[dict] = []
         self.participants: list[CallLogParticipant] = []
         self.recordings: list = []

--- a/wazo_call_logd/tests/test_utils.py
+++ b/wazo_call_logd/tests/test_utils.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from wazo_call_logd.utils import OrderedDefaultDict, find
+from wazo_call_logd.utils import find
 
 
 class TestFind(TestCase):
@@ -23,41 +23,3 @@ class TestFind(TestCase):
         collection = range(10)
         pred = lambda x: x > 5  # noqa: E731
         self.assertEqual(find(collection, pred), 6)
-
-
-class TestDefaultdict(TestCase):
-    def test_default_list(self):
-        """
-        Simple multidict/accumulator use case example
-        """
-        s = [('yellow', 1), ('blue', 2), ('yellow', 3), ('blue', 4), ('red', 1)]
-        d = OrderedDefaultDict(default=list)
-        for k, v in s:
-            d[k].append(v)
-
-        # because of the ordered dict backing, we expect items to appear according to insertion order of keys
-        self.assertEqual(
-            list(d.items()), [('yellow', [1, 3]), ('blue', [2, 4]), ('red', [1])]
-        )
-
-    def test_counter(self):
-        """
-        Simple counter use case example
-        """
-        s = 'mississippi'
-        d = OrderedDefaultDict(default=int)
-        for k in s:
-            d[k] += 1
-
-        self.assertEqual(list(d.items()), [('m', 1), ('i', 4), ('s', 4), ('p', 2)])
-
-    def test_set_ordering(self):
-        """
-        Insertion order is maintained on iteration over keys and items
-        """
-        d = OrderedDefaultDict()
-        for i in range(10):
-            d[i] = i
-
-        self.assertEqual(list(d.keys()), list(range(10)))
-        self.assertEqual(list(d.items()), list(zip(range(10), range(10))))

--- a/wazo_call_logd/utils.py
+++ b/wazo_call_logd/utils.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections import OrderedDict
 from collections.abc import Iterable
 from typing import Callable, TypeVar
 
@@ -14,33 +13,3 @@ def find(col: Iterable[T], pred: Callable[[T], bool]) -> T | None:
     for x in col:
         if pred(x):
             return x
-
-
-class OrderedDefaultDict(OrderedDict):
-    """
-    https://gist.github.com/ohe/1605376
-    Default Dict Implementation built upon OrderedDict(because collections.defaultdict and collections.OrderedDict are not composable)
-    Representation of a default dict:
-    >>> OrderedDefaultDict([('foo', 'bar'), ('bar', 'baz'])
-    OrderedDefaultDict(None, OrderedDict([('foo', 'bar'), ('bar', 'baz')]))
-    """
-
-    def __init__(self, *args, **kwargs):
-        self.default = kwargs.pop('default', None)
-        super().__init__(*args, **kwargs)
-
-    def __repr__(self):
-        return 'defaultdict(%s, %s)' % (self.default, super().__repr__())
-
-    def __missing__(self, key):
-        if self.default:
-            self[key] = value = self.default()
-            return value
-        else:
-            raise KeyError(key)
-
-    def __getitem__(self, key):
-        try:
-            return super().__getitem__(key)
-        except KeyError:
-            return self.__missing__(key)


### PR DESCRIPTION
reason: No reason to maintain custom code when the built-ins already fulfill the role. Dictionaries (including defaultdict) are sorted since Python 3.7