### PR TITLE
Wazo 3214 retention cleanup on tenant deleted

### DIFF
--- a/integration_tests/suite/helpers/bus.py
+++ b/integration_tests/suite/helpers/bus.py
@@ -14,3 +14,7 @@ class CallLogBusClient(BusClient):
             'name': 'CEL',
         }
         self.publish(payload, headers={'name': 'CEL'})
+
+    def send_tenant_deleted(self, tenant_uuid):
+        payload = {'data': {'uuid': tenant_uuid}, 'name': 'auth_tenant_deleted'}
+        self.publish(payload, headers={'name': 'auth_tenant_deleted'})

--- a/integration_tests/suite/helpers/database.py
+++ b/integration_tests/suite/helpers/database.py
@@ -393,6 +393,12 @@ class DatabaseQueries:
         query.delete()
         session.commit()
 
+    def find_retentions(self, tenant_uuid):
+        session = self.Session()
+        query = session.query(Retention)
+        query = query.filter(Retention.tenant_uuid == tenant_uuid)
+        return query.all()
+
     def delete_recording_by_call_log_id(self, call_log_id):
         session = self.Session()
         session.query(Recording).filter(Recording.call_log_id == call_log_id).delete()

--- a/integration_tests/suite/test_retention.py
+++ b/integration_tests/suite/test_retention.py
@@ -5,6 +5,7 @@ from hamcrest import (
     assert_that,
     calling,
     contains,
+    empty,
     has_entries,
     has_properties,
 )
@@ -129,3 +130,16 @@ class TestRetention(IntegrationTest):
             )
 
         until.assert_(event_received, tries=3)
+
+    @retention()
+    def test_tenant_cleanup(self, retention: dict):
+        self.bus.send_tenant_deleted(retention['tenant_uuid'])
+
+        def assert_no_retention_for_tenant():
+            with self.database.queries() as queries:
+                retentions = queries.find_retentions(
+                    tenant_uuid=retention['tenant_uuid']
+                )
+                assert_that(retentions, empty())
+
+        until.assert_(assert_no_retention_for_tenant, tries=5)

--- a/wazo_call_logd/controller.py
+++ b/wazo_call_logd/controller.py
@@ -95,6 +95,7 @@ class Controller:
                 'token_renewer': self.token_renewer,
                 'status_aggregator': self.status_aggregator,
                 'bus_publisher': self.bus_publisher,
+                'bus_consumer': self.bus_consumer,
             },
         )
 

--- a/wazo_call_logd/database/queries/base.py
+++ b/wazo_call_logd/database/queries/base.py
@@ -2,19 +2,21 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from contextlib import contextmanager
+from typing import Iterator
 
 from sqlalchemy import exc
 
 from wazo_call_logd.exceptions import DatabaseServiceUnavailable
+from sqlalchemy.orm import Session as BaseSession, scoped_session
 
 
 class BaseDAO:
-    def __init__(self, Session):
+    def __init__(self, Session: scoped_session):
         self._Session = Session
 
     @contextmanager
-    def new_session(self):
-        session = self._Session()
+    def new_session(self) -> Iterator[BaseSession]:
+        session: BaseSession = self._Session()
         try:
             yield session
             session.commit()

--- a/wazo_call_logd/database/queries/retention.py
+++ b/wazo_call_logd/database/queries/retention.py
@@ -3,6 +3,9 @@
 
 from .base import BaseDAO
 from ..models import Config, Retention, Tenant
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class RetentionDAO(BaseDAO):
@@ -52,3 +55,16 @@ class RetentionDAO(BaseDAO):
             session.add(retention)
             session.flush()
             session.expunge(retention)
+
+    def delete(self, tenant_uuid):
+        with self.new_session() as session:
+            deleted_count = (
+                session.query(Retention)
+                .filter(Retention.tenant_uuid == tenant_uuid)
+                .delete()
+            )
+            logger.debug(
+                "Deleted %d Retention entries for tenant_uuid %s",
+                deleted_count,
+                tenant_uuid,
+            )

--- a/wazo_call_logd/plugins/retention/listener.py
+++ b/wazo_call_logd/plugins/retention/listener.py
@@ -1,0 +1,15 @@
+from wazo_call_logd.database.queries.retention import RetentionDAO
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RententionListener:
+    dao: RetentionDAO
+
+    def tenant_deleted(self, event: dict):
+        tenant_uuid = event['uuid']
+        logger.info("cleaning up retention settings for deleted tenant %s", tenant_uuid)
+        self.dao.delete(tenant_uuid)

--- a/wazo_call_logd/plugins/retention/plugin.py
+++ b/wazo_call_logd/plugins/retention/plugin.py
@@ -4,16 +4,26 @@
 from .http import RetentionResource
 from .services import RetentionService
 from .notifier import RetentionNotifier
+from .listener import RententionListener
+
+from wazo_call_logd.bus import BusConsumer, BusPublisher
+from wazo_call_logd.database.queries import DAO
+from flask_restful import Api
 
 
 class Plugin:
     def load(self, dependencies):
-        api = dependencies['api']
-        dao = dependencies['dao']
-        bus_publisher = dependencies['bus_publisher']
+        api: Api = dependencies['api']
+        dao: DAO = dependencies['dao']
+        bus_publisher: BusPublisher = dependencies['bus_publisher']
+        bus_consumer: BusConsumer = dependencies['bus_consumer']
 
         notifier = RetentionNotifier(bus_publisher)
         service = RetentionService(dao, notifier)
+        listener = RententionListener(dao.retention)
+
+        bus_consumer.subscribe('auth_tenant_deleted', listener.tenant_deleted)
+
         api.add_resource(
             RetentionResource,
             '/retention',


### PR DESCRIPTION
https://wazo-dev.atlassian.net/browse/WAZO-3214

Out of scope of ticket, but if retention policy is worth cleaning up, what about call logs and recordings? If retention policy is deleted, automatic data purge likely won't happen?