### PR TITLE
cron: remove wazo-call-logd-sync-db

### DIFF
--- a/debian/cron.d
+++ b/debian/cron.d
@@ -3,4 +3,3 @@
 #
 
 25 4 * * * root . /etc/profile.d/xivo_uuid.sh && /usr/bin/wazo-call-logs
-43 3 * * * root /usr/bin/wazo-call-logd-sync-db --quiet


### PR DESCRIPTION
Why:

* This commands removes all call logs without filtering