### PR TITLE
WAZO-2350: Add `conversation_id` to Call Log

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # See https://pre-commit.com for more information
 repos:
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
       - id: flake8
         # Required to make flake8 read from pyproject.toml for now :(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ## 24.09
 
-* The `/cdr` resource now includes the `conversation_id` field
-* The `/cdr` endpoint is now filterable by `conversation_id` value
+* The `CDR` resource now includes the `conversation_id` field
+
+* The following endpoints are now filterable by `conversation_id` value
+
+  * `GET /cdr`
+  * `GET /users/me/cdr`
+  * `GET /users/{user_uuid}/cdr`
 
 ## 23.01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 24.09
+
+* The `/cdr` resource now includes the `conversation_id` field
+* The `/cdr` endpoint is now filterable by `conversation_id` value
+
 ## 23.01
 
 * Bus configuration keys changed:

--- a/integration_tests/suite/test_cdr.py
+++ b/integration_tests/suite/test_cdr.py
@@ -2382,3 +2382,62 @@ class TestListCDR(IntegrationTest):
                 )
             ),
         )
+
+    @call_log(
+        **{'id': 10},
+        conversation_id='123.1',
+        tenant_uuid=str(USERS_TENANT),
+        participants=[
+            {'user_uuid': str(USER_1_UUID), 'line_id': '1', 'role': 'source'}
+        ],
+    )
+    @call_log(
+        **{'id': 11},
+        conversation_id='123.2',
+        tenant_uuid=str(USERS_TENANT),
+        participants=[
+            {'user_uuid': str(USER_1_UUID), 'line_id': '1', 'role': 'source'}
+        ],
+    )
+    @call_log(
+        **{'id': 12},
+        conversation_id='123.3',
+        tenant_uuid=str(USERS_TENANT),
+        participants=[
+            {'user_uuid': str(USER_2_UUID), 'line_id': '1', 'role': 'source'}
+        ],
+    )
+    def test_user_list_by_conversation_id(self):
+        self.call_logd.set_token(USER_1_TOKEN)
+
+        assert_that(
+            self.call_logd.cdr.list_from_user(conversation_id='123.1'),
+            has_entries(
+                items=has_items(
+                    has_entries(id=10),
+                ),
+                filtered=1,
+                total=2,
+            ),
+        )
+
+        assert_that(
+            self.call_logd.cdr.list_from_user(conversation_id='123.3'),
+            has_entries(
+                items=empty(),
+                filtered=0,
+                total=2,
+            ),
+        )
+
+        self.call_logd.set_token(USER_2_TOKEN)
+        assert_that(
+            self.call_logd.cdr.list_from_user(conversation_id='123.3'),
+            has_entries(
+                items=has_items(
+                    has_entries(id=12),
+                ),
+                filtered=1,
+                total=1,
+            ),
+        )

--- a/wazo_call_logd/database/alembic/versions/2ff862045893_cdr_add_conversation_id.py
+++ b/wazo_call_logd/database/alembic/versions/2ff862045893_cdr_add_conversation_id.py
@@ -1,0 +1,30 @@
+"""cdr_add_conversation_id
+
+Revision ID: 2ff862045893
+Revises: 9cafdec9b563
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '2ff862045893'
+down_revision = '9cafdec9b563'
+
+CALL_LOG_TABLE_NAME = 'call_logd_call_log'
+CALL_LOG_INDEX_NAME = f'{CALL_LOG_TABLE_NAME}__idx__conversation_id'
+
+
+def upgrade():
+    op.add_column(CALL_LOG_TABLE_NAME, sa.Column('conversation_id', sa.String(255)))
+    op.create_index(
+        index_name=CALL_LOG_INDEX_NAME,
+        table_name=CALL_LOG_TABLE_NAME,
+        columns=['conversation_id'],
+    )
+
+
+def downgrade():
+    op.drop_index(CALL_LOG_INDEX_NAME)
+    op.drop_column(CALL_LOG_TABLE_NAME, 'conversation_id')

--- a/wazo_call_logd/database/alembic/versions/2ff862045893_cdr_add_conversation_id.py
+++ b/wazo_call_logd/database/alembic/versions/2ff862045893_cdr_add_conversation_id.py
@@ -5,8 +5,8 @@ Revises: 9cafdec9b563
 
 """
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '2ff862045893'

--- a/wazo_call_logd/database/models.py
+++ b/wazo_call_logd/database/models.py
@@ -246,6 +246,7 @@ class Recording(Base):
         ),
         nullable=False,
     )
+    conversation_id = association_proxy('call_log', 'conversation_id')
 
     @property
     def filename(self):

--- a/wazo_call_logd/database/models.py
+++ b/wazo_call_logd/database/models.py
@@ -60,6 +60,7 @@ class CallLog(Base):
     destination_line_identity = Column(String(255))
     direction = Column(String(255))
     user_field = Column(String(255))
+    conversation_id = Column(String(255), index=True)
 
     recordings = relationship(
         'Recording',

--- a/wazo_call_logd/database/models.py
+++ b/wazo_call_logd/database/models.py
@@ -60,7 +60,7 @@ class CallLog(Base):
     destination_line_identity = Column(String(255))
     direction = Column(String(255))
     user_field = Column(String(255))
-    conversation_id = Column(String(255), index=True)
+    conversation_id = Column(String(255))
 
     recordings = relationship(
         'Recording',
@@ -116,6 +116,7 @@ class CallLog(Base):
     cel_ids = []
 
     __table_args__ = (
+        Index('call_logd_call_log__idx__conversation_id', 'conversation_id'),
         CheckConstraint(
             direction.in_(['inbound', 'internal', 'outbound']),
             name='call_logd_call_log_direction_check',

--- a/wazo_call_logd/database/queries/call_log.py
+++ b/wazo_call_logd/database/queries/call_log.py
@@ -8,7 +8,7 @@ from typing import Any, TypedDict
 import sqlalchemy as sa
 from sqlalchemy import and_, distinct, func, sql
 from sqlalchemy.dialects.postgresql import ARRAY, UUID
-from sqlalchemy.orm import Query, joinedload, subqueryload, selectinload
+from sqlalchemy.orm import Query, joinedload, selectinload, subqueryload
 
 from wazo_call_logd.datatypes import CallDirection, OrderDirection
 

--- a/wazo_call_logd/database/queries/call_log.py
+++ b/wazo_call_logd/database/queries/call_log.py
@@ -258,6 +258,9 @@ class CallLogDAO(BaseDAO):
             else:
                 query = query.filter(~CallLog.recordings.any())
 
+        if conversation_id := params.get('conversation_id'):
+            query = query.filter(CallLog.conversation_id == conversation_id)
+
         return query
 
     def create_from_list(self, call_logs):

--- a/wazo_call_logd/database/queries/call_log.py
+++ b/wazo_call_logd/database/queries/call_log.py
@@ -8,7 +8,7 @@ from typing import Any, TypedDict
 import sqlalchemy as sa
 from sqlalchemy import and_, distinct, func, sql
 from sqlalchemy.dialects.postgresql import ARRAY, UUID
-from sqlalchemy.orm import Query, joinedload, subqueryload
+from sqlalchemy.orm import Query, joinedload, subqueryload, selectinload
 
 from wazo_call_logd.datatypes import CallDirection, OrderDirection
 
@@ -51,6 +51,7 @@ class CallLogDAO(BaseDAO):
             query = session.query(CallLog).options(
                 joinedload('participants'),
                 joinedload('recordings'),
+                selectinload('recordings.call_log'),
                 subqueryload('source_participant'),
                 subqueryload('destination_participant'),
             )
@@ -113,6 +114,7 @@ class CallLogDAO(BaseDAO):
         query = query.options(
             joinedload('participants'),
             joinedload('recordings'),
+            selectinload('recordings.call_log'),
             subqueryload('source_participant'),
             subqueryload('destination_participant'),
         )

--- a/wazo_call_logd/generator.py
+++ b/wazo_call_logd/generator.py
@@ -239,8 +239,8 @@ class CallLogsGenerator:
 
             call_log = RawCallLog()
 
-            # NOTE (jalie): can use min() here because linkedid use same format
-            # Should probably do something in the case we have many linkedids
+            # Call pickups may have multiple linkedids.
+            # In that case, use the linkedid of the caller, i.e. the smaller one.
             call_log.conversation_id = min(linkedids)
             call_log.cel_ids = [cel.id for cel in cels_by_call]
 

--- a/wazo_call_logd/generator.py
+++ b/wazo_call_logd/generator.py
@@ -238,6 +238,10 @@ class CallLogsGenerator:
                 continue
 
             call_log = RawCallLog()
+
+            # NOTE (jalie): can use min() here because linkedid use same format
+            # Should probably do something in the case we have many linkedids
+            call_log.conversation_id = min(linkedids)
             call_log.cel_ids = [cel.id for cel in cels_by_call]
 
             interpretor = self._get_interpretor(cels_by_call)

--- a/wazo_call_logd/generator.py
+++ b/wazo_call_logd/generator.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2022-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
@@ -169,7 +169,7 @@ def _group_cels_by_shared_channels(
     # this correlation is transitive,
     # i.e. if a channel is shared between sequence a and b, and between b and c,
     # then a and c are also correlated
-    correlation_groups: list[(set[str], set[str], list[CEL])] = []
+    correlation_groups: list[tuple[set[str], set[str], list[CEL]]] = []
     for linkedid, cels in linkedid_sequences:
         uniqueids = {cel.uniqueid for cel in cels}
         correlated_sequences = False

--- a/wazo_call_logd/plugins/cdr/api.yml
+++ b/wazo_call_logd/plugins/cdr/api.yml
@@ -25,6 +25,7 @@ paths:
       - $ref: '#/parameters/distinct'
       - $ref: '#/parameters/recorded'
       - $ref: '#/parameters/format'
+      - $ref: '#/parameters/conversation_id'
       responses:
         '200':
           description: List CDR
@@ -347,6 +348,12 @@ parameters:
   email:
     name: email
     description: E-mail address
+    type: string
+    in: query
+  conversation_id:
+    name: conversation_id
+    description: Filter by conversation identifier
+    required: false
     type: string
     in: query
 definitions:

--- a/wazo_call_logd/plugins/cdr/api.yml
+++ b/wazo_call_logd/plugins/cdr/api.yml
@@ -181,6 +181,7 @@ paths:
       - $ref: '#/parameters/distinct'
       - $ref: '#/parameters/recorded'
       - $ref: '#/parameters/format'
+      - $ref: '#/parameters/conversation_id'
       responses:
         '200':
           description: List CDR
@@ -215,6 +216,7 @@ paths:
       - $ref: '#/parameters/distinct'
       - $ref: '#/parameters/recorded'
       - $ref: '#/parameters/format'
+      - $ref: '#/parameters/conversation_id'
       responses:
         '200':
           description: List CDR
@@ -447,6 +449,8 @@ definitions:
         - inbound
         - internal
         - outbound
+      conversation_id:
+        type: string
       tags:
         type: array
         items:

--- a/wazo_call_logd/plugins/cdr/schemas.py
+++ b/wazo_call_logd/plugins/cdr/schemas.py
@@ -15,6 +15,7 @@ class RecordingSchema(Schema):
     end_time = fields.DateTime()
     deleted = fields.Boolean()
     filename = fields.String()
+    conversation_id = fields.String()
 
 
 class RecordingMediaDeleteRequestSchema(Schema):
@@ -119,6 +120,7 @@ class CDRSchema(Schema):
     answer = fields.DateTime(attribute='date_answer')
     duration = fields.TimeDelta(default=None, attribute='marshmallow_duration')
     call_direction = fields.String(attribute='direction')
+    conversation_id = fields.String()
     destination_details = DestinationDetailsField(
         BaseDestinationDetailsSchema,
         attribute='destination_details_dict',
@@ -145,7 +147,9 @@ class CDRSchema(Schema):
     source_name = fields.String()
     source_user_uuid = fields.UUID()
     tags = fields.List(fields.String(), attribute='marshmallow_tags')
-    recordings = fields.Nested('RecordingSchema', many=True, default=[])
+    recordings = fields.Nested(
+        'RecordingSchema', many=True, default=[], exclude=('conversation_id',)
+    )
 
     @pre_dump
     def _compute_fields(self, data, **kwargs):

--- a/wazo_call_logd/plugins/cdr/schemas.py
+++ b/wazo_call_logd/plugins/cdr/schemas.py
@@ -7,6 +7,7 @@ from xivo.mallow.validate import Length, OneOf, Range, Regexp
 from xivo.mallow_helpers import Schema
 
 NUMBER_REGEX = r'^_?[0-9]+_?$'
+CONVERSATION_ID_REGEX = r'^[0-9]+\.[0-9]+$'
 
 
 class RecordingSchema(Schema):
@@ -183,6 +184,12 @@ class CDRListRequestSchema(CDRListingBase):
     distinct = fields.String(validate=OneOf(['peer_exten']), missing=None)
     recorded = fields.Boolean(missing=None)
     format = fields.String(validate=OneOf(['csv', 'json']), missing=None)
+    conversation_id = fields.String(
+        validate=Regexp(
+            CONVERSATION_ID_REGEX, error='not a valid conversation identifier'
+        ),
+        missing=None,
+    )
 
     @post_load
     def map_order_field(self, in_data, **kwargs):

--- a/wazo_call_logd/plugins/cdr/services.py
+++ b/wazo_call_logd/plugins/cdr/services.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
@@ -35,6 +35,7 @@ class SearchParams(TypedDict, total=False):
     me_user_uuid: UUID
     user_uuids: list[UUID]
     recorded: bool
+    conversation_id: str
 
 
 class CDRService:

--- a/wazo_call_logd/raw_call_log.py
+++ b/wazo_call_logd/raw_call_log.py
@@ -50,6 +50,7 @@ class RawCallLog:
         self.participants: list[CallLogParticipant] = []
         self.recordings: list = []
         self.cel_ids: list[int] = []
+        self.conversation_id: str | None = None
         self.interpret_callee_bridge_enter: bool = True
         self.interpret_caller_xivo_user_fwd: bool = True
         # flag to indicate if authoritative destination information is identified
@@ -108,6 +109,7 @@ class RawCallLog:
             source_line_identity=self.source_line_identity,
             direction=self.direction,
             destination_details=self.destination_details,
+            conversation_id=self.conversation_id,
         )
         result.participants = self.participants
         result.cel_ids = self.cel_ids

--- a/wazo_call_logd/tests/test_generator.py
+++ b/wazo_call_logd/tests/test_generator.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
@@ -338,7 +338,7 @@ class TestGroupCelsBySharedChannels(TestCase):
         linkedid_2 = '123456789.5'
         # uniqueids sequence for this linkedid overlap first sequence over the first 3 elements
         uniqueid_cycle_2 = itertools.cycle(
-            linkedid_1.replace('.0', f'.{i+3}') for i in range(5)
+            linkedid_1.replace('.0', f'.{i + 3}') for i in range(5)
         )
         cel_sequence_2 = self._generate_cel_sequence(
             linkedid_2, lambda: next(uniqueid_cycle_2), cel_count=10


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/wazo-bus/pull/109

## Proposed changes by this PR
- Call Log objects now has `conversation_id` attribute
- Migration script to add conversation_id column to CDR + index
- Added ability to query CDR by conversation_id (`/cdr?conversation_id=...`)