### PR TITLE
cdr recordings: include storage path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 24.12
+
+* The CDR recording resource attribute `uuid` is now equal to the recording filename.
+
 ## 24.09
 
 * The `CDR` resource now includes the `conversation_id` field.

--- a/integration_tests/suite/test_recording_generation.py
+++ b/integration_tests/suite/test_recording_generation.py
@@ -1,6 +1,7 @@
-# Copyright 2021-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import uuid
 from datetime import datetime as dt
 from datetime import timezone
 
@@ -22,7 +23,7 @@ eventtype        | eventtime              | channame            | uniqueid      
 CHAN_START       | 2021-01-01 00:00:00.01 | SIP/aaaaaa-00000001 | 1000000000.01 | 1000000000.1 |
 APP_START        | 2021-01-01 00:00:00.02 | SIP/aaaaaa-00000001 | 1000000000.01 | 1000000000.1 |
 CHAN_START       | 2021-01-01 00:00:00.03 | SIP/bbbbbb-00000002 | 1000000000.02 | 1000000000.1 |
-MIXMONITOR_START | 2021-01-01 00:00:00.04 | SIP/bbbbbb-00000002 | 1000000000.02 | 1000000000.1 | {"filename":"/tmp/foobar.wav","mixmonitor_id":"0x000000000001"}
+MIXMONITOR_START | 2021-01-01 00:00:00.04 | SIP/bbbbbb-00000002 | 1000000000.02 | 1000000000.1 | {"filename":"/var/lib/wazo/sounds/tenants/54eb71f8-1f4b-4ae4-8730-638062fbe521/monitor/aaf26cdf-7e59-4630-b703-9c0bfb7c158c.wav","mixmonitor_id":"0x000000000001"}
 ANSWER           | 2021-01-01 00:00:00.05 | SIP/bbbbbb-00000002 | 1000000000.02 | 1000000000.1 |
 ANSWER           | 2021-01-01 00:00:00.06 | SIP/aaaaaa-00000001 | 1000000000.01 | 1000000000.1 |
 BRIDGE_ENTER     | 2021-01-01 00:00:00.07 | SIP/aaaaaa-00000001 | 1000000000.01 | 1000000000.1 |
@@ -43,7 +44,8 @@ LINKEDID_END     | 2021-01-01 00:00:00.16 | SIP/aaaaaa-00000001 | 1000000000.01 
             has_properties(
                 start_time=dt.fromisoformat('2021-01-01 00:00:00.040000+00:00'),
                 end_time=dt.fromisoformat('2021-01-01 00:00:00.090000+00:00'),
-                path='/tmp/foobar.wav',
+                path='/var/lib/wazo/sounds/tenants/54eb71f8-1f4b-4ae4-8730-638062fbe521/monitor/aaf26cdf-7e59-4630-b703-9c0bfb7c158c.wav',
+                uuid=uuid.UUID('aaf26cdf-7e59-4630-b703-9c0bfb7c158c'),
             ),
         )
 

--- a/wazo_call_logd/cel_interpretor.py
+++ b/wazo_call_logd/cel_interpretor.py
@@ -6,6 +6,7 @@ import json
 import logging
 import re
 import urllib.parse
+import uuid
 from datetime import datetime
 from typing import Callable, TypedDict
 
@@ -26,6 +27,14 @@ WAIT_FOR_MOBILE_REGEX = re.compile(r'^Local/(\S+)@wazo_wait_for_registration-\S+
 MATCHING_MOBILE_PEER_REGEX = re.compile(r'^PJSIP/(\S+)-\S+$')
 MEETING_EXTENSION_REGEX = re.compile(r'^wazo-meeting-.*$')
 KEY_PAIR_SEQ_REGEX = re.compile(r'\s*(\w+):\s*([^,:]+),?')
+UUID_REGEX = re.compile(
+    r'[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}'
+)
+# The recording path regex must be kept synced with CALL_RECORDING_FILENAME_TEMPLATE
+# in wazo-calld and wazo-agid
+RECORDING_PATH_REGEX = re.compile(
+    rf'/var/lib/wazo/sounds/tenants/({UUID_REGEX.pattern})/monitor/({UUID_REGEX.pattern}).wav'
+)
 
 
 def default_interpretors() -> list[AbstractCELInterpretor]:
@@ -337,6 +346,10 @@ class CallerCELInterpretor(AbstractCELInterpretor):
             path=extra['filename'],
             mixmonitor_id=extra['mixmonitor_id'],
         )
+        if matches := RECORDING_PATH_REGEX.match(extra['filename']):
+            recording_uuid_str = matches.group(2)
+            recording.uuid = uuid.UUID(recording_uuid_str)
+
         call.recordings.append(recording)
         return call
 
@@ -742,6 +755,10 @@ class CalleeCELInterpretor(AbstractCELInterpretor):
             path=extra['filename'],
             mixmonitor_id=extra['mixmonitor_id'],
         )
+        if matches := RECORDING_PATH_REGEX.match(extra['filename']):
+            recording_uuid_str = matches.group(2)
+            recording.uuid = uuid.UUID(recording_uuid_str)
+
         call.recordings.append(recording)
         return call
 


### PR DESCRIPTION
Why:

* Application developer may need to process the files for external
  analysis (e.g. transcription)