### PR TITLE
schema: add missing call_log_id indexes

### DIFF
--- a/wazo_call_logd/database/alembic/versions/6190f9a543ef_add_missing_call_log_index.py
+++ b/wazo_call_logd/database/alembic/versions/6190f9a543ef_add_missing_call_log_index.py
@@ -1,0 +1,40 @@
+"""add missing call-log index
+
+Revision ID: 6190f9a543ef
+Revises: 08ba4cd18b85
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '6190f9a543ef'
+down_revision = '08ba4cd18b85'
+
+INDEXES = [
+    (
+        'call_logd_call_log_destination__idx__call_log_id',
+        'call_logd_call_log_destination',
+        'call_log_id',
+    ),
+    (
+        'call_logd_recording__idx__call_log_id',
+        'call_logd_recording',
+        'call_log_id',
+    ),
+]
+
+
+def upgrade():
+    for idx_name, tbl_name, col_name in INDEXES:
+        op.create_index(
+            index_name=idx_name,
+            table_name=tbl_name,
+            columns=[col_name],
+        )
+
+
+def downgrade():
+    for idx_name, _, __ in INDEXES:
+        op.drop_index(idx_name)

--- a/wazo_call_logd/database/models.py
+++ b/wazo_call_logd/database/models.py
@@ -170,6 +170,7 @@ class Destination(Base):
 
     __table_args__ = (
         Index('call_logd_call_log_destination__idx__uuid', 'uuid'),
+        Index('call_logd_call_log_destination__idx__call_log_id', 'call_log_id'),
         CheckConstraint(
             destination_details_key.in_(
                 [
@@ -254,6 +255,7 @@ class CallLogParticipant(Base):
 @generic_repr
 class Recording(Base):
     __tablename__ = 'call_logd_recording'
+    __table_args__ = (Index('call_logd_recording__idx__call_log_id', 'call_log_id'),)
 
     uuid = Column(
         UUIDType(),


### PR DESCRIPTION
The missing index on the call_log_id FK make the delete cascade slow and resource intensive