### PR TITLE
Use marshmallow version 3.18.0 from Bookworm

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ jinja2==3.0.3  # from flask
 jsonpatch==1.25
 kombu==5.0.2
 markupsafe==2.0.1 # from jinja
-marshmallow==3.10.0
+marshmallow==3.18.0
 psycopg2-binary==2.8.6
 python-dateutil==2.8.1  # from marshmallow, to accept more date formats
 pytz==2021.1

--- a/wazo_call_logd/plugins/cdr/schemas.py
+++ b/wazo_call_logd/plugins/cdr/schemas.py
@@ -24,17 +24,19 @@ class RecordingMediaDeleteRequestSchema(Schema):
 
 
 class CDRListingBase(Schema):
-    from_ = fields.DateTime(data_key='from', attribute='start', missing=None)
-    until = fields.DateTime(attribute='end', missing=None)
-    search = fields.String(missing=None)
+    from_ = fields.DateTime(data_key='from', attribute='start', load_default=None)
+    until = fields.DateTime(attribute='end', load_default=None)
+    search = fields.String(load_default=None)
     call_direction = fields.String(
-        validate=OneOf(['internal', 'inbound', 'outbound']), missing=None
+        validate=OneOf(['internal', 'inbound', 'outbound']), load_default=None
     )
-    number = fields.String(validate=Regexp(NUMBER_REGEX), missing=None)
-    tags = fields.List(fields.String(), missing=[])
-    user_uuid = fields.List(fields.String(), missing=[], attribute='user_uuids')
-    from_id = fields.Integer(validate=Range(min=0), attribute='start_id', missing=None)
-    recurse = fields.Boolean(missing=False)
+    number = fields.String(validate=Regexp(NUMBER_REGEX), load_default=None)
+    tags = fields.List(fields.String(), load_default=[])
+    user_uuid = fields.List(fields.String(), load_default=[], attribute='user_uuids')
+    from_id = fields.Integer(
+        validate=Range(min=0), attribute='start_id', load_default=None
+    )
+    recurse = fields.Boolean(load_default=False)
 
     @pre_load
     def convert_tags_and_user_uuid_to_list(self, data, **kwargs):
@@ -47,11 +49,11 @@ class CDRListingBase(Schema):
 
 
 class RecordingMediaExportRequestSchema(CDRListingBase):
-    email = fields.Email(missing=None)
+    email = fields.Email(load_default=None)
 
 
 class RecordingMediaExportBodySchema(Schema):
-    cdr_ids = fields.List(fields.Integer(), missing=None)
+    cdr_ids = fields.List(fields.Integer(), load_default=None)
 
 
 class RecordingMediaExportSchema(Schema):
@@ -59,7 +61,7 @@ class RecordingMediaExportSchema(Schema):
 
 
 class BaseDestinationDetailsSchema(Schema):
-    type = fields.String(required=True, default='unknown')
+    type = fields.String(required=True, dump_default='unknown')
 
 
 class DestinationConferenceDetails(BaseDestinationDetailsSchema):
@@ -119,7 +121,7 @@ class CDRSchema(Schema):
     end = fields.DateTime(attribute='date_end')
     answered = fields.Boolean(attribute='marshmallow_answered')
     answer = fields.DateTime(attribute='date_answer')
-    duration = fields.TimeDelta(default=None, attribute='marshmallow_duration')
+    duration = fields.TimeDelta(dump_default=None, attribute='marshmallow_duration')
     call_direction = fields.String(attribute='direction')
     conversation_id = fields.String()
     destination_details = DestinationDetailsField(
@@ -150,7 +152,7 @@ class CDRSchema(Schema):
     source_user_uuid = fields.UUID()
     tags = fields.List(fields.String(), attribute='marshmallow_tags')
     recordings = fields.Nested(
-        'RecordingSchema', many=True, default=[], exclude=('conversation_id',)
+        'RecordingSchema', many=True, dump_default=[], exclude=('conversation_id',)
     )
 
     @pre_dump
@@ -175,21 +177,21 @@ class CDRSchema(Schema):
 
 
 class CDRListRequestSchema(CDRListingBase):
-    direction = fields.String(validate=OneOf(['asc', 'desc']), missing='desc')
+    direction = fields.String(validate=OneOf(['asc', 'desc']), load_default='desc')
     order = fields.String(
         validate=OneOf(set(CDRSchema().fields) - {'end', 'tags', 'recordings'}),
-        missing='start',
+        load_default='start',
     )
-    limit = fields.Integer(validate=Range(min=0), missing=1000)
-    offset = fields.Integer(validate=Range(min=0), missing=None)
-    distinct = fields.String(validate=OneOf(['peer_exten']), missing=None)
-    recorded = fields.Boolean(missing=None)
-    format = fields.String(validate=OneOf(['csv', 'json']), missing=None)
+    limit = fields.Integer(validate=Range(min=0), load_default=1000)
+    offset = fields.Integer(validate=Range(min=0), load_default=None)
+    distinct = fields.String(validate=OneOf(['peer_exten']), load_default=None)
+    recorded = fields.Boolean(load_default=None)
+    format = fields.String(validate=OneOf(['csv', 'json']), load_default=None)
     conversation_id = fields.String(
         validate=Regexp(
             CONVERSATION_ID_REGEX, error='not a valid conversation identifier'
         ),
-        missing=None,
+        load_default=None,
     )
 
     @post_load

--- a/wazo_call_logd/plugins/retention/schemas.py
+++ b/wazo_call_logd/plugins/retention/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from marshmallow import validates_schema
@@ -10,9 +10,9 @@ from xivo.mallow_helpers import Schema
 
 class RetentionSchema(Schema):
     tenant_uuid = fields.UUID(dump_only=True)
-    cdr_days = fields.Integer(validate=Range(min=0), missing=None)
-    export_days = fields.Integer(validate=Range(min=0), missing=None)
-    recording_days = fields.Integer(validate=Range(min=0), missing=None)
+    cdr_days = fields.Integer(validate=Range(min=0), load_default=None)
+    export_days = fields.Integer(validate=Range(min=0), load_default=None)
+    recording_days = fields.Integer(validate=Range(min=0), load_default=None)
     default_cdr_days = fields.Integer(dump_only=True)
     default_export_days = fields.Integer(dump_only=True)
     default_recording_days = fields.Integer(dump_only=True)

--- a/wazo_call_logd/plugins/support_center/schemas.py
+++ b/wazo_call_logd/plugins/support_center/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from datetime import time
@@ -15,7 +15,7 @@ HOUR_REGEX = r"^([0,1][0-9]|2[0-3]):[0-5][0-9]$"
 class _StatisticsPeriodSchema(Schema):
     from_ = fields.String(attribute='from', data_key='from')
     until = fields.String()
-    tenant_uuid = fields.UUID(default=None)
+    tenant_uuid = fields.UUID(dump_default=None)
 
     @pre_dump
     def convert_from_and_until_to_isoformat(self, data, **kwargs):
@@ -27,13 +27,13 @@ class _StatisticsPeriodSchema(Schema):
 
 
 class AgentStatisticsSchema(_StatisticsPeriodSchema):
-    agent_id = fields.Integer(default=None)
-    agent_number = fields.String(default=None)
-    answered = fields.Integer(default=0)
-    conversation_time = fields.Integer(default=0)
-    login_time = fields.Integer(default=0)
-    pause_time = fields.Integer(default=0)
-    wrapup_time = fields.Integer(default=0)
+    agent_id = fields.Integer(dump_default=None)
+    agent_number = fields.String(dump_default=None)
+    answered = fields.Integer(dump_default=0)
+    conversation_time = fields.Integer(dump_default=0)
+    login_time = fields.Integer(dump_default=0)
+    pause_time = fields.Integer(dump_default=0)
+    wrapup_time = fields.Integer(dump_default=0)
 
 
 class AgentStatisticsSchemaList(Schema):
@@ -42,44 +42,44 @@ class AgentStatisticsSchemaList(Schema):
 
 
 class QueueStatisticsSchema(_StatisticsPeriodSchema):
-    queue_id = fields.Integer(default=None)
-    queue_name = fields.String(default=None)
-    received = fields.Integer(attribute='total', default=0)
-    answered = fields.Integer(default=0)
-    abandoned = fields.Integer(default=0)
-    closed = fields.Integer(default=0)
-    not_answered = fields.Integer(attribute='timeout', default=0)
-    saturated = fields.Integer(default=0)
-    blocked = fields.Integer(attribute='blocking', default=0)
-    average_waiting_time = fields.Integer(default=None)
-    answered_rate = fields.Float(default=None)
-    quality_of_service = fields.Float(attribute='qos', default=None)
+    queue_id = fields.Integer(dump_default=None)
+    queue_name = fields.String(dump_default=None)
+    received = fields.Integer(attribute='total', dump_default=0)
+    answered = fields.Integer(dump_default=0)
+    abandoned = fields.Integer(dump_default=0)
+    closed = fields.Integer(dump_default=0)
+    not_answered = fields.Integer(attribute='timeout', dump_default=0)
+    saturated = fields.Integer(dump_default=0)
+    blocked = fields.Integer(attribute='blocking', dump_default=0)
+    average_waiting_time = fields.Integer(dump_default=None)
+    answered_rate = fields.Float(dump_default=None)
+    quality_of_service = fields.Float(attribute='qos', dump_default=None)
 
 
 class _QoSSchema(Schema):
-    min_ = fields.Integer(default=None, attribute='min', data_key='min')
-    max_ = fields.Integer(default=None, attribute='max', data_key='max')
-    answered = fields.Integer(default=0)
-    abandoned = fields.Integer(default=0)
+    min_ = fields.Integer(dump_default=None, attribute='min', data_key='min')
+    max_ = fields.Integer(dump_default=None, attribute='max', data_key='max')
+    answered = fields.Integer(dump_default=0)
+    abandoned = fields.Integer(dump_default=0)
 
 
 class QueueStatisticsQoSSchema(_StatisticsPeriodSchema):
-    queue_id = fields.Integer(default=None)
-    queue_name = fields.String(default=None)
+    queue_id = fields.Integer(dump_default=None)
+    queue_name = fields.String(dump_default=None)
     quality_of_service = fields.List(fields.Nested(_QoSSchema))
 
 
 class _StatisticsListRequestSchema(Schema):
-    from_ = fields.DateTime(data_key='from', missing=None)
-    until = fields.DateTime(missing=None)
+    from_ = fields.DateTime(data_key='from', load_default=None)
+    until = fields.DateTime(load_default=None)
     day_start_time = fields.String(attribute='start_time', validate=Regexp(HOUR_REGEX))
     day_end_time = fields.String(attribute='end_time', validate=Regexp(HOUR_REGEX))
     week_days = fields.List(
         fields.Integer(),
-        missing=[1, 2, 3, 4, 5, 6, 7],
+        load_default=[1, 2, 3, 4, 5, 6, 7],
         validate=ContainsOnly([1, 2, 3, 4, 5, 6, 7]),
     )
-    timezone = fields.String(validate=OneOf(pytz.all_timezones), missing='UTC')
+    timezone = fields.String(validate=OneOf(pytz.all_timezones), load_default='UTC')
 
     def _normalize_datetime(self, dt, timezone):
         if not dt.tzinfo:
@@ -157,7 +157,7 @@ class QueueStatisticsRequestSchema(QueueStatisticsListRequestSchema):
 
 class QueueStatisticsQoSRequestSchema(_StatisticsListRequestSchema):
     interval = fields.String(validate=OneOf(['hour', 'day', 'month']))
-    qos_thresholds = fields.List(fields.Integer(validate=Range(min=0)), missing=[])
+    qos_thresholds = fields.List(fields.Integer(validate=Range(min=0)), load_default=[])
 
     @pre_load
     def convert_qos_thresholds_to_list(self, data, **kwargs):


### PR DESCRIPTION
This change uses the Bookworm version of marshmallow to reduce the scope of changes that are going to happen when doing the upgrade