### PR TITLE
call log generation: ignore CEL from SIP chat messages

### DIFF
--- a/integration_tests/suite/test_db_cel.py
+++ b/integration_tests/suite/test_db_cel.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from datetime import timedelta as td
@@ -290,3 +290,9 @@ class TestCEL(DBIntegrationTest):
                 has_property('id', cel2['id']),
             ),
         )
+
+    @cel(linkedid='1', channame='Message/ast_msg_queue')
+    def test_find_last_unprocessed_ignore_sip_chat_messages(self, cel):
+        older = NOW - td(hours=1)
+        result = self.dao.cel.find_last_unprocessed(older=older)
+        assert_that(result, empty())

--- a/wazo_call_logd/database/queries/cel.py
+++ b/wazo_call_logd/database/queries/cel.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.alchemy.cel import CEL
@@ -56,6 +56,7 @@ class CELDAO(BaseDAO):
             subquery = (
                 session.query(CEL.uniqueid)
                 .filter(CEL.call_log_id.is_(None))
+                .filter(CEL.channame != 'Message/ast_msg_queue')  # ignore SIP chat
                 .order_by(CEL.eventtime.desc())
             )
 


### PR DESCRIPTION
Why:

* They cause errors when processing CELs, since they don't have the same
  data