### PR TITLE
remove no-op transaction with psycopg2

### DIFF
--- a/wazo_call_logd/init_db.py
+++ b/wazo_call_logd/init_db.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import argparse
@@ -67,12 +67,11 @@ def main():
         sys.exit(1)
 
     conn.autocommit = True
-    with conn:
-        with conn.cursor() as cursor:
-            if not db_helper.db_user_exists(cursor, args.owner):
-                db_helper.create_db_user(cursor, args.owner, args.password)
-            if not db_helper.db_exists(cursor, args.db):
-                db_helper.create_db(cursor, args.db, args.owner)
+    with conn.cursor() as cursor:
+        if not db_helper.db_user_exists(cursor, args.owner):
+            db_helper.create_db_user(cursor, args.owner, args.password)
+        if not db_helper.db_exists(cursor, args.db):
+            db_helper.create_db(cursor, args.db, args.owner)
 
     conn = psycopg2.connect(args.call_logd_db_uri)
     with conn:


### PR DESCRIPTION
- psycopg <2.9 (bullseye): when autocommit=True, the context manager is a noop
- psycopg >= 2.9 (bookworm): context manager always open a transaction
  and it's imcompatible with CREATE DATABASE