### PR TITLE
WAZO-4166: allow ordering by call_status

### DIFF
--- a/integration_tests/suite/test_cdr.py
+++ b/integration_tests/suite/test_cdr.py
@@ -2607,27 +2607,19 @@ class TestListCDR(IntegrationTest):
         date_answer='2025-01-01 00:01:00',
         date_end='2025-01-01 00:02:00',
     )
-    @call_log(
-        **{'id': 2},
-        blocked=False,
-        date='2025-01-02 00:00:00',
-        date_answer='2025-01-02 00:01:00',
-        date_end='2025-01-02 00:02:00',
-    )
-    @call_log(**{'id': 3}, blocked=True)
-    @call_log(**{'id': 4}, blocked=False)
+    @call_log(**{'id': 2}, blocked=True)
+    @call_log(**{'id': 3}, blocked=False)
     def test_list_order_by_call_status(self):
         # default = don't list blocked calls
         assert_that(
             self.call_logd.cdr.list(order='call_status'),
             has_entries(
                 items=contains_exactly(
-                    has_entries(id=2),
                     has_entries(id=1),
-                    has_entries(id=4),
+                    has_entries(id=3),
                 ),
-                filtered=3,
-                total=4,
+                filtered=2,
+                total=3,
             ),
         )
 
@@ -2635,11 +2627,10 @@ class TestListCDR(IntegrationTest):
             self.call_logd.cdr.list(order='call_status', direction='asc'),
             has_entries(
                 items=contains_exactly(
-                    has_entries(id=4),
-                    has_entries(id=2),
+                    has_entries(id=3),
                     has_entries(id=1),
                 ),
-                filtered=3,
-                total=4,
+                filtered=2,
+                total=3,
             ),
         )

--- a/integration_tests/suite/test_cdr.py
+++ b/integration_tests/suite/test_cdr.py
@@ -2599,3 +2599,47 @@ class TestListCDR(IntegrationTest):
                 total=1,
             ),
         )
+
+    @call_log(
+        **{'id': 1},
+        blocked=False,
+        date='2025-01-01 00:00:00',
+        date_answer='2025-01-01 00:01:00',
+        date_end='2025-01-01 00:02:00',
+    )
+    @call_log(
+        **{'id': 2},
+        blocked=False,
+        date='2025-01-02 00:00:00',
+        date_answer='2025-01-02 00:01:00',
+        date_end='2025-01-02 00:02:00',
+    )
+    @call_log(**{'id': 3}, blocked=True)
+    @call_log(**{'id': 4}, blocked=False)
+    def test_list_order_by_call_status(self):
+        # default = don't list blocked calls
+        assert_that(
+            self.call_logd.cdr.list(order='call_status'),
+            has_entries(
+                items=contains_exactly(
+                    has_entries(id=2),
+                    has_entries(id=1),
+                    has_entries(id=4),
+                ),
+                filtered=3,
+                total=4,
+            ),
+        )
+
+        assert_that(
+            self.call_logd.cdr.list(order='call_status', direction='asc'),
+            has_entries(
+                items=contains_exactly(
+                    has_entries(id=4),
+                    has_entries(id=2),
+                    has_entries(id=1),
+                ),
+                filtered=3,
+                total=4,
+            ),
+        )

--- a/wazo_call_logd/database/queries/call_log.py
+++ b/wazo_call_logd/database/queries/call_log.py
@@ -7,7 +7,7 @@ import datetime as dt
 from typing import Any, TypedDict
 
 import sqlalchemy as sa
-from sqlalchemy import and_, distinct, func, sql
+from sqlalchemy import and_, case, distinct, func, sql
 from sqlalchemy.dialects.postgresql import ARRAY, UUID
 from sqlalchemy.orm import Query, joinedload, selectinload, subqueryload
 
@@ -78,6 +78,14 @@ class CallLogDAO(BaseDAO):
                     order_field = CallLog.date_end - CallLog.date_answer
                 elif params['order'] == 'marshmallow_answered':
                     order_field = CallLog.date_answer
+                elif params['order'] == 'marshmallow_call_status':
+                    order_field = case(
+                        [
+                            (CallLog.date_answer.isnot(None), 3),
+                            (CallLog.blocked.is_(True), 2),
+                        ],
+                        else_=1,
+                    )
                 else:
                     order_field = getattr(CallLog, params['order'])
             if params.get('direction') == 'desc':


### PR DESCRIPTION
WAZO-4166
prevents call-logd from throwing a 500 when ordering CDRs by call_status