### PR TITLE
ITEM-228-unanswered-cdr

### DIFF
--- a/wazo_call_logd/cel_interpretor.py
+++ b/wazo_call_logd/cel_interpretor.py
@@ -825,6 +825,17 @@ class CalleeCELInterpretor(AbstractCELInterpretor):
             call.bridges[bridge.id] = bridge
 
         call.raw_participants[cel.channame].update(answered=True)
+
+        # Fallback: caller BRIDGE_ENTER may be suppressed by Asterisk's move-swap
+        # bridge optimization. Use the callee's answer time as the next best proxy.
+        if (
+            not call.date_answer
+            and bridge
+            and bridge.technology != 'holding_bridge'
+            and not cel.channame.lower().startswith('local/')
+        ):
+            call.date_answer = parse_eventtime(cel.eventtime)
+
         # only consider the first bridge_enter for destination identity info
         if call.interpret_callee_bridge_enter and (
             not call.authoritative_destination_info or call.was_forwarded

--- a/wazo_call_logd/tests/test_generator_scenarios.py
+++ b/wazo_call_logd/tests/test_generator_scenarios.py
@@ -1053,3 +1053,48 @@ class TestCallLogGenerationScenarios(TestCase):
                 ),
             ),
         )
+
+    @raw_cels(
+        '''
+        eventtype    | eventtime                     | cid_name | cid_num      | cid_ani | exten | context   | channame                        | linkedid     | uniqueid     | extra
+        -------------+-------------------------------+----------+--------------+---------+-------+-----------+---------------------------------+--------------+--------------+-----------------------------------------------
+        CHAN_START   | 2024-01-01 10:00:00.000000+00 | Caller   | +15551234567 |         | 1000  | from-pstn | PJSIP/trunk-00000001            | 1704103200.1 | 1704103200.1 |
+        XIVO_INCALL  | 2024-01-01 10:00:00.100000+00 | Caller   | +15551234567 |         | s     | did       | PJSIP/trunk-00000001            | 1704103200.1 | 1704103200.1 | {"extra":"54eb71f8-1f4b-4ae4-8730-638062fbe521"}
+        ANSWER       | 2024-01-01 10:00:00.200000+00 | Caller   | +15551234567 |         | s     | from-pstn | PJSIP/trunk-00000001            | 1704103200.1 | 1704103200.1 |
+        CHAN_START   | 2024-01-01 10:00:01.000000+00 |          |              |         | s     | queue     | Local/d729503f@queue-000000f0;1 | 1704103200.1 | 1704103201.2 |
+        CHAN_START   | 2024-01-01 10:00:01.001000+00 |          |              |         | s     | queue     | Local/d729503f@queue-000000f0;2 | 1704103200.1 | 1704103201.3 |
+        CHAN_START   | 2024-01-01 10:00:06.000000+00 | Agent    | 8001         |         | s     | internal  | PJSIP/agent-00000002            | 1704103200.1 | 1704103206.4 |
+        ANSWER       | 2024-01-01 10:00:07.000000+00 | Agent    | 8001         |         | s     | internal  | PJSIP/agent-00000002            | 1704103200.1 | 1704103206.4 |
+        BRIDGE_ENTER | 2024-01-01 10:00:07.100000+00 | Agent    | 8001         |         | s     | internal  | PJSIP/agent-00000002            | 1704103200.1 | 1704103206.4 | {"bridge_id":"74eb7e46-0000-0000-0000-000000000001","bridge_technology":"simple_bridge"}
+        BRIDGE_ENTER | 2024-01-01 10:00:07.110000+00 |          |              |         | s     | queue     | Local/d729503f@queue-000000f0;2 | 1704103200.1 | 1704103201.3 | {"bridge_id":"74eb7e46-0000-0000-0000-000000000001","bridge_technology":"simple_bridge"}
+        BRIDGE_EXIT  | 2024-01-01 10:00:07.200000+00 |          |              |         | s     | queue     | Local/d729503f@queue-000000f0;2 | 1704103200.1 | 1704103201.3 | {"bridge_id":"74eb7e46-0000-0000-0000-000000000001","bridge_technology":"simple_bridge"}
+        BRIDGE_EXIT  | 2024-01-01 10:00:07.210000+00 | Agent    | 8001         |         | s     | internal  | PJSIP/agent-00000002            | 1704103200.1 | 1704103206.4 | {"bridge_id":"74eb7e46-0000-0000-0000-000000000001","bridge_technology":"simple_bridge"}
+        HANGUP       | 2024-01-01 10:00:07.220000+00 |          |              |         | s     | queue     | Local/d729503f@queue-000000f0;1 | 1704103200.1 | 1704103201.2 | {"hangupcause":16,"hangupsource":"","dialstatus":""}
+        CHAN_END     | 2024-01-01 10:00:07.220000+00 |          |              |         | s     | queue     | Local/d729503f@queue-000000f0;1 | 1704103200.1 | 1704103201.2 |
+        HANGUP       | 2024-01-01 10:00:07.230000+00 |          |              |         | s     | queue     | Local/d729503f@queue-000000f0;2 | 1704103200.1 | 1704103201.3 | {"hangupcause":16,"hangupsource":"","dialstatus":""}
+        CHAN_END     | 2024-01-01 10:00:07.230000+00 |          |              |         | s     | queue     | Local/d729503f@queue-000000f0;2 | 1704103200.1 | 1704103201.3 |
+        HANGUP       | 2024-01-01 10:00:17.000000+00 | Agent    | 8001         |         | s     | internal  | PJSIP/agent-00000002            | 1704103200.1 | 1704103206.4 | {"hangupcause":16,"hangupsource":"PJSIP/agent-00000002","dialstatus":""}
+        CHAN_END     | 2024-01-01 10:00:17.000000+00 | Agent    | 8001         |         | s     | internal  | PJSIP/agent-00000002            | 1704103200.1 | 1704103206.4 |
+        HANGUP       | 2024-01-01 10:00:17.100000+00 | Caller   | +15551234567 |         | s     | from-pstn | PJSIP/trunk-00000001            | 1704103200.1 | 1704103200.1 | {"hangupcause":16,"hangupsource":"PJSIP/agent-00000002","dialstatus":"ANSWER"}
+        CHAN_END     | 2024-01-01 10:00:17.100000+00 | Caller   | +15551234567 |         | s     | from-pstn | PJSIP/trunk-00000001            | 1704103200.1 | 1704103200.1 |
+        LINKEDID_END | 2024-01-01 10:00:17.100000+00 | Caller   | +15551234567 |         | s     | from-pstn | PJSIP/trunk-00000001            | 1704103200.1 | 1704103200.1 |
+        '''
+    )
+    def test_queue_call_answered_via_move_swap_optimization(self, cels: list[CEL]):
+        """
+        Asterisk's bridge move-swap optimization eliminates Local channel pairs by directly
+        swapping the real callee into the caller's bridge, bypassing the normal bridge path.
+        This suppresses the BRIDGE_ENTER CEL event that would set date_answer on the caller
+        channel. The fallback in CalleeCELInterpretor.interpret_bridge_enter must fire instead.
+        """
+        call_logs = self.generator.call_logs_from_cel(cels)
+        assert call_logs
+        assert len(call_logs) == 1
+
+        assert_that(
+            call_logs[0],
+            has_properties(
+                direction='inbound',
+                date_answer=datetime_close_to('2024-01-01T10:00:07.1+00:00'),
+            ),
+        )


### PR DESCRIPTION
Asterisk's bridge move-swap optimization swaps the real callee channel
directly into the caller's bridge, bypassing bridge_channel_internal_push_unlocked().
This suppresses the BRIDGE_ENTER CEL that CallerCELInterpretor relies on
to set date_answer, leaving it NULL and making the CDR show as unanswered.

When the caller's BRIDGE_ENTER is missing, fall back to the callee's
BRIDGE_ENTER time (emitted reliably before the swap). Only applies when
date_answer is not already set, bridge is not a holding bridge, and the
channel is not a Local channel.

Note: As the failing scenario could not be reproduced, this fix has been
applied on a best-effort basis.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `date_answer` is derived for some bridged calls, which can affect call answered/unanswered reporting and downstream CDRs. Scope is small but touches core call-log interpretation logic.
> 
> **Overview**
> Fixes inbound call logs incorrectly marked *unanswered* when Asterisk’s bridge move-swap optimization suppresses the caller `BRIDGE_ENTER` event.
> 
> `CalleeCELInterpretor.interpret_bridge_enter` now sets `call.date_answer` from the callee’s `BRIDGE_ENTER` timestamp when it’s still unset (excluding `holding_bridge` and `Local/*` channels), and a new generator scenario test asserts the expected `date_answer` in this queue/move-swap case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52458a78d6c55752dcdc3557d73acc6f9cc5ea14. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->