### PR TITLE
ITEM-256-nginx-cdr-timeout

### DIFF
--- a/etc/nginx/locations/https-available/wazo-call-logd
+++ b/etc/nginx/locations/https-available/wazo-call-logd
@@ -1,8 +1,16 @@
+location ^~ /api/call-logd/1.0/cdr {
+    proxy_pass http://127.0.0.1:9298/1.0/cdr;
+    proxy_read_timeout 300s;
+    include /etc/nginx/wazo-call-logd-shared.conf;
+}
+
+location ^~ /api/call-logd/1.0/users/me/cdr {
+    proxy_pass http://127.0.0.1:9298/1.0/users/me/cdr;
+    proxy_read_timeout 300s;
+    include /etc/nginx/wazo-call-logd-shared.conf;
+}
+
 location ^~ /api/call-logd/ {
     proxy_pass http://127.0.0.1:9298/;
-
-    proxy_set_header    Host                $http_host;
-    proxy_set_header    X-Script-Name       /api/call-logd;
-    proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
-    proxy_set_header    X-Forwarded-Proto   $scheme;
+    include /etc/nginx/wazo-call-logd-shared.conf;
 }

--- a/etc/nginx/wazo-call-logd-shared.conf
+++ b/etc/nginx/wazo-call-logd-shared.conf
@@ -1,0 +1,4 @@
+proxy_set_header    Host                $http_host;
+proxy_set_header    X-Script-Name       /api/call-logd;
+proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+proxy_set_header    X-Forwarded-Proto   $scheme;


### PR DESCRIPTION
Why: CSV export of large datasets (tens of thousands of CDRs) takes over
60s due to SQLAlchemy ORM hydration and Marshmallow serialization, causing
Nginx to return 504 before the response is ready.

Add dedicated location blocks for /cdr and /users/me/cdr with a 5-minute
timeout. Extract shared proxy headers into wazo-call-logd-shared.conf

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Nginx config-only change; primary risk is misrouting or unintended timeout behavior for the new CDR-specific locations.
> 
> **Overview**
> Adds dedicated Nginx `location` blocks for `/api/call-logd/1.0/cdr` and `/api/call-logd/1.0/users/me/cdr` with `proxy_read_timeout 300s` to prevent 504s on long CDR exports.
> 
> Extracts the common `proxy_set_header` directives into a new `/etc/nginx/wazo-call-logd-shared.conf` and includes it from all `call-logd` locations to reduce duplication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07b959b6aae5dcca44959c10b8775f27bf53bee4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->