### PR TITLE
docker: pin rabbitmq to version 3

### DIFF
--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - "5432"
 
   rabbitmq:
-    image: rabbitmq
+    image: rabbitmq:3
     ports:
       - "5672"
     volumes:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only pins the RabbitMQ Docker image used by integration tests, reducing variability but potentially changing broker behavior versus `latest`.
> 
> **Overview**
> Pins the integration test `docker-compose.yml` RabbitMQ service from the unversioned `rabbitmq` image to `rabbitmq:3` to avoid unexpected changes from upstream `latest` updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 618a87bb0403b7f71827585ca9e9f5c3ba276c0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->