### PR TITLE
[ITEM-394] Surface voicemail redirections in CDR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@
   `max_threads` is now a ceiling the pool grows to under load, not a fixed
   thread count.
 
+* Calls redirected to a voicemail are now surfaced in CDRs:
+
+  * The `call_status` field of a CDR can take the new value `voicemail`, meaning the call was
+    redirected to a voicemail and was not answered elsewhere. Statuses are mutually exclusive and
+    resolved in this order: `blocked`, `voicemail`, `answered`, `unknown`.
+  * `call_status=voicemail` is accepted as a filter on `GET /cdr` and `GET /users/me/cdr`.
+  * `destination_details` can take the new `type` `voicemail`, carrying `voicemail_id` and
+    `voicemail_name`.
+
+* The `destination_details` of a CDR whose call reached a voicemail now reports `type` `voicemail`
+  instead of `type` `user`. Consumers reading `destination_details.user_uuid` on those CDRs must
+  read the top-level `destination_user_uuid` field instead, which is unchanged.
+
+* The `call_status=unknown` filter on `GET /cdr` and `GET /users/me/cdr` now returns only the CDRs
+  whose `call_status` is `unknown`. It was previously accepted but ignored, returning every CDR
+  including blocked ones.
+
 ## 26.07
 
 * Agent statistics now include a per-queue breakdown:

--- a/integration_tests/suite/test_cdr.py
+++ b/integration_tests/suite/test_cdr.py
@@ -2623,6 +2623,17 @@ class TestListCDR(IntegrationTest):
             ),
         )
 
+        # unknown = neither answered, voicemail, nor blocked; must not leak
+        # blocked rows (id=4).
+        assert_that(
+            self.call_logd.cdr.list(call_status='unknown'),
+            has_entries(
+                items=contains_exactly(has_entries(id=2, call_status='unknown')),
+                filtered=1,
+                total=4,
+            ),
+        )
+
     @call_log(
         **{'id': 10},
         date='2017-03-23 00:00:00',

--- a/integration_tests/suite/test_cdr.py
+++ b/integration_tests/suite/test_cdr.py
@@ -2587,26 +2587,39 @@ class TestListCDR(IntegrationTest):
 
     @call_log(**{'id': 1}, reached_voicemail=True)
     @call_log(**{'id': 2}, blocked=False)
+    @call_log(
+        **{'id': 3},
+        reached_voicemail=True,
+        date='2017-03-23 00:00:00',
+        date_answer='2017-03-23 00:01:00',
+        date_end='2017-03-23 00:02:00',
+    )
+    @call_log(**{'id': 4}, reached_voicemail=True, blocked=True)
     def test_list_by_call_status_voicemail(self):
-        # a voicemail redirection is surfaced and listed by default (not hidden)
+        # a voicemail redirection is surfaced and listed by default (blocked hidden).
+        # id=3 reached voicemail but was answered -> status answered, not voicemail.
         assert_that(
             self.call_logd.cdr.list(),
             has_entries(
                 items=has_items(
                     has_entries(id=1, call_status='voicemail'),
                     has_entries(id=2, call_status='unknown'),
+                    has_entries(id=3, call_status='answered'),
                 ),
-                filtered=2,
-                total=2,
+                filtered=3,
+                total=4,
             ),
         )
 
+        # the voicemail filter must match only rows whose computed status is
+        # voicemail (unanswered and not blocked), not answered/blocked rows that
+        # also carry reached_voicemail (id=3, id=4).
         assert_that(
             self.call_logd.cdr.list(call_status='voicemail'),
             has_entries(
                 items=contains_exactly(has_entries(id=1, call_status='voicemail')),
                 filtered=1,
-                total=2,
+                total=4,
             ),
         )
 

--- a/integration_tests/suite/test_cdr.py
+++ b/integration_tests/suite/test_cdr.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import csv
@@ -2582,6 +2582,31 @@ class TestListCDR(IntegrationTest):
                         ),
                     ),
                 )
+            ),
+        )
+
+    @call_log(**{'id': 1}, reached_voicemail=True)
+    @call_log(**{'id': 2}, blocked=False)
+    def test_list_by_call_status_voicemail(self):
+        # a voicemail redirection is surfaced and listed by default (not hidden)
+        assert_that(
+            self.call_logd.cdr.list(),
+            has_entries(
+                items=has_items(
+                    has_entries(id=1, call_status='voicemail'),
+                    has_entries(id=2, call_status='unknown'),
+                ),
+                filtered=2,
+                total=2,
+            ),
+        )
+
+        assert_that(
+            self.call_logd.cdr.list(call_status='voicemail'),
+            has_entries(
+                items=contains_exactly(has_entries(id=1, call_status='voicemail')),
+                filtered=1,
+                total=2,
             ),
         )
 

--- a/integration_tests/suite/test_cdr.py
+++ b/integration_tests/suite/test_cdr.py
@@ -2635,6 +2635,41 @@ class TestListCDR(IntegrationTest):
         )
 
     @call_log(
+        **{'id': 1},
+        blocked=True,
+        date='2017-03-23 00:00:00',
+        date_answer='2017-03-23 00:01:00',
+        date_end='2017-03-23 00:02:00',
+    )
+    @call_log(
+        **{'id': 2},
+        blocked=False,
+        date='2017-03-23 00:00:00',
+        date_answer='2017-03-23 00:01:00',
+        date_end='2017-03-23 00:02:00',
+    )
+    def test_list_by_call_status_blocked_supersedes_answered(self):
+        # id=1 is both blocked and answered; blocked wins when computing
+        # call_status, so the answered filter must not return it.
+        assert_that(
+            self.call_logd.cdr.list(call_status='answered'),
+            has_entries(
+                items=contains_exactly(has_entries(id=2, call_status='answered')),
+                filtered=1,
+                total=2,
+            ),
+        )
+
+        assert_that(
+            self.call_logd.cdr.list(call_status='blocked'),
+            has_entries(
+                items=contains_exactly(has_entries(id=1, call_status='blocked')),
+                filtered=1,
+                total=2,
+            ),
+        )
+
+    @call_log(
         **{'id': 10},
         date='2017-03-23 00:00:00',
         date_answer='2017-03-23 00:01:00',

--- a/wazo_call_logd/cel_interpretor.py
+++ b/wazo_call_logd/cel_interpretor.py
@@ -233,6 +233,24 @@ class AbstractCELInterpretor:
             logger.debug("Ignoring uninterpretable CEL event type %s", eventtype)
             return call
 
+    def interpret_voicemail_app_start(self, cel, call):
+        # VoiceMail() marks a "leave a message" redirection on either the caller
+        # or (after a transfer) the callee channel; VoiceMailMain() is excluded.
+        # Requires `voicemail` in cel.conf `apps=` so Asterisk emits APP_START.
+        if cel.appname.lower() == 'voicemail':
+            mailbox = cel.appdata.split(',', 1)[0]
+            number, _, context = mailbox.partition('@')
+            call.reached_voicemail = True
+            call.voicemail_number = number or None
+            call.voicemail_context = context or None
+            logger.debug(
+                'Identified voicemail redirection from app_start event '
+                '(id=%s, mailbox=%s)',
+                cel.id,
+                mailbox,
+            )
+        return call
+
 
 class DispatchCELInterpretor:
     def __init__(self, caller_cel_interpretor, callee_cel_interpretor):
@@ -316,25 +334,9 @@ class CallerCELInterpretor(AbstractCELInterpretor):
     def interpret_app_start(self, cel, call):
         call.user_field = cel.userfield
 
-        # The native VoiceMail() application is the single entry point of every
-        # "leave a message" dialplan path (user no-answer, direct vmbox, vmbox
-        # feature). VoiceMailMain() (message retrieval) is deliberately excluded.
-        # This must run before the was_forwarded early-return below, since the
-        # user no-answer path sets was_forwarded via XIVO_USER_FWD.
-        # NOTE: requires `voicemail` in cel.conf `apps=` for Asterisk to emit the
-        # APP_START; the dialplan uses both `Voicemail(` and `VoiceMail(` casings.
-        if cel.appname.lower() == 'voicemail':
-            mailbox = cel.appdata.split(',', 1)[0]
-            number, _, context = mailbox.partition('@')
-            call.reached_voicemail = True
-            call.voicemail_number = number or None
-            call.voicemail_context = context or None
-            logger.debug(
-                'Identified voicemail redirection from app_start event '
-                '(id=%s, mailbox=%s)',
-                cel.id,
-                mailbox,
-            )
+        # Must run before the was_forwarded early-return below, since the user
+        # no-answer path sets was_forwarded via XIVO_USER_FWD.
+        self.interpret_voicemail_app_start(cel, call)
 
         if call.was_forwarded:
             return call
@@ -727,6 +729,7 @@ class CalleeCELInterpretor(AbstractCELInterpretor):
         self.eventtype_map = {
             CELEventType.chan_start: self.interpret_chan_start,
             CELEventType.chan_end: self.interpret_chan_end,
+            CELEventType.app_start: self.interpret_voicemail_app_start,
             CELEventType.bridge_enter: self.interpret_bridge_enter,
             CELEventType.bridge_start: self.interpret_bridge_enter,
             CELEventType.mixmonitor_start: self.interpret_mixmonitor_start,

--- a/wazo_call_logd/cel_interpretor.py
+++ b/wazo_call_logd/cel_interpretor.py
@@ -316,6 +316,26 @@ class CallerCELInterpretor(AbstractCELInterpretor):
     def interpret_app_start(self, cel, call):
         call.user_field = cel.userfield
 
+        # The native VoiceMail() application is the single entry point of every
+        # "leave a message" dialplan path (user no-answer, direct vmbox, vmbox
+        # feature). VoiceMailMain() (message retrieval) is deliberately excluded.
+        # This must run before the was_forwarded early-return below, since the
+        # user no-answer path sets was_forwarded via XIVO_USER_FWD.
+        # NOTE: requires `voicemail` in cel.conf `apps=` for Asterisk to emit the
+        # APP_START; the dialplan uses both `Voicemail(` and `VoiceMail(` casings.
+        if cel.appname.lower() == 'voicemail':
+            mailbox = cel.appdata.split(',', 1)[0]
+            number, _, context = mailbox.partition('@')
+            call.reached_voicemail = True
+            call.voicemail_number = number or None
+            call.voicemail_context = context or None
+            logger.debug(
+                'Identified voicemail redirection from app_start event '
+                '(id=%s, mailbox=%s)',
+                cel.id,
+                mailbox,
+            )
+
         if call.was_forwarded:
             return call
 

--- a/wazo_call_logd/cel_interpretor.py
+++ b/wazo_call_logd/cel_interpretor.py
@@ -214,6 +214,26 @@ def parse_eventtime(eventtime: str | datetime) -> datetime:
 EventInterpretor = Callable[[CEL, RawCallLog], RawCallLog]
 
 
+def interpret_voicemail_app_start(cel, call):
+    # VoiceMail() marks a "leave a message" redirection on whichever channel
+    # runs it (caller, transferred callee, or originated); VoiceMailMain() is
+    # excluded. Requires `voicemail` in cel.conf `apps=` so Asterisk emits
+    # APP_START.
+    if cel.appname.lower() == 'voicemail':
+        mailbox = cel.appdata.split(',', 1)[0]
+        number, _, context = mailbox.partition('@')
+        call.reached_voicemail = True
+        call.voicemail_number = number or None
+        call.voicemail_context = context or None
+        logger.debug(
+            'Identified voicemail redirection from app_start event '
+            '(id=%s, mailbox=%s)',
+            cel.id,
+            mailbox,
+        )
+    return call
+
+
 class AbstractCELInterpretor:
     eventtype_map: dict[str, EventInterpretor] = {}
 
@@ -232,24 +252,6 @@ class AbstractCELInterpretor:
         else:
             logger.debug("Ignoring uninterpretable CEL event type %s", eventtype)
             return call
-
-    def interpret_voicemail_app_start(self, cel, call):
-        # VoiceMail() marks a "leave a message" redirection on either the caller
-        # or (after a transfer) the callee channel; VoiceMailMain() is excluded.
-        # Requires `voicemail` in cel.conf `apps=` so Asterisk emits APP_START.
-        if cel.appname.lower() == 'voicemail':
-            mailbox = cel.appdata.split(',', 1)[0]
-            number, _, context = mailbox.partition('@')
-            call.reached_voicemail = True
-            call.voicemail_number = number or None
-            call.voicemail_context = context or None
-            logger.debug(
-                'Identified voicemail redirection from app_start event '
-                '(id=%s, mailbox=%s)',
-                cel.id,
-                mailbox,
-            )
-        return call
 
 
 class DispatchCELInterpretor:
@@ -336,7 +338,7 @@ class CallerCELInterpretor(AbstractCELInterpretor):
 
         # Must run before the was_forwarded early-return below, since the user
         # no-answer path sets was_forwarded via XIVO_USER_FWD.
-        self.interpret_voicemail_app_start(cel, call)
+        interpret_voicemail_app_start(cel, call)
 
         if call.was_forwarded:
             return call
@@ -729,7 +731,7 @@ class CalleeCELInterpretor(AbstractCELInterpretor):
         self.eventtype_map = {
             CELEventType.chan_start: self.interpret_chan_start,
             CELEventType.chan_end: self.interpret_chan_end,
-            CELEventType.app_start: self.interpret_voicemail_app_start,
+            CELEventType.app_start: interpret_voicemail_app_start,
             CELEventType.bridge_enter: self.interpret_bridge_enter,
             CELEventType.bridge_start: self.interpret_bridge_enter,
             CELEventType.mixmonitor_start: self.interpret_mixmonitor_start,
@@ -1010,6 +1012,11 @@ class LocalOriginateCELInterpretor:
         )
         if local_channel1_app_start:
             call.user_field = local_channel1_app_start.userfield
+
+        # An originated call that ends in the destination's voicemail runs
+        # VoiceMail() on one of its channels; detect it like the other paths.
+        for app_start in (cel for cel in cels if cel.eventtype == 'APP_START'):
+            interpret_voicemail_app_start(app_start, call)
 
         other_channels_start = [
             cel

--- a/wazo_call_logd/cel_interpretor.py
+++ b/wazo_call_logd/cel_interpretor.py
@@ -214,7 +214,7 @@ def parse_eventtime(eventtime: str | datetime) -> datetime:
 EventInterpretor = Callable[[CEL, RawCallLog], RawCallLog]
 
 
-def interpret_voicemail_app_start(cel, call):
+def interpret_voicemail_app_start(cel: CEL, call: RawCallLog) -> RawCallLog:
     # VoiceMail() marks a "leave a message" redirection on whichever channel
     # runs it (caller, transferred callee, or originated); VoiceMailMain() is
     # excluded. Requires `voicemail` in cel.conf `apps=` so Asterisk emits

--- a/wazo_call_logd/cel_interpretor.py
+++ b/wazo_call_logd/cel_interpretor.py
@@ -220,7 +220,9 @@ def interpret_voicemail_app_start(cel, call):
     # excluded. Requires `voicemail` in cel.conf `apps=` so Asterisk emits
     # APP_START.
     if cel.appname.lower() == 'voicemail':
-        mailbox = cel.appdata.split(',', 1)[0]
+        # appdata is "mailbox[,options]"; a custom dialplan may pass an Asterisk
+        # "&"-separated multi-mailbox list, so attribute the CDR to the first.
+        mailbox = cel.appdata.split(',', 1)[0].split('&', 1)[0]
         number, _, context = mailbox.partition('@')
         call.reached_voicemail = True
         call.voicemail_number = number or None

--- a/wazo_call_logd/database/alembic/versions/0776735d0419_add_reached_voicemail_and_voicemail_.py
+++ b/wazo_call_logd/database/alembic/versions/0776735d0419_add_reached_voicemail_and_voicemail_.py
@@ -49,10 +49,24 @@ def upgrade():
 
 def downgrade():
     op.drop_constraint(DESTINATION_KEY_CHECK, DESTINATION_TABLE, type_='check')
-    # Postgres validates the narrowed constraint against existing rows, so drop
-    # the voicemail rows this revision allowed before recreating OLD_KEYS.
-    destination = sa.table(DESTINATION_TABLE, sa.column('destination_details_key'))
-    op.execute(destination.delete().where(_key_in(VOICEMAIL_KEYS)))
+    # Drop the whole voicemail destination group: a surviving type='voicemail'
+    # row passes OLD_KEYS but makes rolled-back code KeyError on serialization.
+    # Must run before recreating OLD_KEYS, which Postgres validates against rows.
+    destination = sa.table(
+        DESTINATION_TABLE,
+        sa.column('call_log_id'),
+        sa.column('destination_details_key'),
+        sa.column('destination_details_value'),
+    )
+    voicemail_call_logs = sa.select(destination.c.call_log_id).where(
+        sa.and_(
+            destination.c.destination_details_key == 'type',
+            destination.c.destination_details_value == 'voicemail',
+        )
+    )
+    op.execute(
+        destination.delete().where(destination.c.call_log_id.in_(voicemail_call_logs))
+    )
     op.create_check_constraint(
         DESTINATION_KEY_CHECK, DESTINATION_TABLE, _key_in(OLD_KEYS)
     )

--- a/wazo_call_logd/database/alembic/versions/0776735d0419_add_reached_voicemail_and_voicemail_.py
+++ b/wazo_call_logd/database/alembic/versions/0776735d0419_add_reached_voicemail_and_voicemail_.py
@@ -28,7 +28,8 @@ OLD_KEYS = (
     'group_label',
     'group_id',
 )
-NEW_KEYS = OLD_KEYS + ('voicemail_id', 'voicemail_name')
+VOICEMAIL_KEYS = ('voicemail_id', 'voicemail_name')
+NEW_KEYS = OLD_KEYS + VOICEMAIL_KEYS
 
 
 def _key_in(keys):
@@ -48,6 +49,10 @@ def upgrade():
 
 def downgrade():
     op.drop_constraint(DESTINATION_KEY_CHECK, DESTINATION_TABLE, type_='check')
+    # Postgres validates the narrowed constraint against existing rows, so drop
+    # the voicemail rows this revision allowed before recreating OLD_KEYS.
+    destination = sa.table(DESTINATION_TABLE, sa.column('destination_details_key'))
+    op.execute(destination.delete().where(_key_in(VOICEMAIL_KEYS)))
     op.create_check_constraint(
         DESTINATION_KEY_CHECK, DESTINATION_TABLE, _key_in(OLD_KEYS)
     )

--- a/wazo_call_logd/database/alembic/versions/0776735d0419_add_reached_voicemail_and_voicemail_.py
+++ b/wazo_call_logd/database/alembic/versions/0776735d0419_add_reached_voicemail_and_voicemail_.py
@@ -1,0 +1,54 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""add reached_voicemail and voicemail destination details
+
+Revision ID: 0776735d0419
+Revises: 48f5f29349c2
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '0776735d0419'
+down_revision = '48f5f29349c2'
+
+DESTINATION_TABLE = 'call_logd_call_log_destination'
+DESTINATION_KEY_CHECK = 'call_logd_call_log_destination_details_key_check'
+
+OLD_KEYS = (
+    'type',
+    'user_uuid',
+    'user_name',
+    'meeting_uuid',
+    'meeting_name',
+    'conference_id',
+    'group_label',
+    'group_id',
+)
+NEW_KEYS = OLD_KEYS + ('voicemail_id', 'voicemail_name')
+
+
+def _key_in(keys):
+    return sa.column('destination_details_key').in_(keys)
+
+
+def upgrade():
+    op.add_column(
+        'call_logd_call_log',
+        sa.Column('reached_voicemail', sa.Boolean),
+    )
+    op.drop_constraint(DESTINATION_KEY_CHECK, DESTINATION_TABLE, type_='check')
+    op.create_check_constraint(
+        DESTINATION_KEY_CHECK, DESTINATION_TABLE, _key_in(NEW_KEYS)
+    )
+
+
+def downgrade():
+    op.drop_constraint(DESTINATION_KEY_CHECK, DESTINATION_TABLE, type_='check')
+    op.create_check_constraint(
+        DESTINATION_KEY_CHECK, DESTINATION_TABLE, _key_in(OLD_KEYS)
+    )
+    op.drop_column('call_logd_call_log', 'reached_voicemail')

--- a/wazo_call_logd/database/models.py
+++ b/wazo_call_logd/database/models.py
@@ -60,6 +60,7 @@ class CallLog(Base):
     destination_internal_context = Column(Text)
     destination_line_identity = Column(String(255))
     blocked = Column(Boolean)
+    reached_voicemail = Column(Boolean)
     direction = Column(String(255))
     user_field = Column(String(255))
     conversation_id = Column(String(255))
@@ -182,6 +183,8 @@ class Destination(Base):
                     'conference_id',
                     'group_label',
                     'group_id',
+                    'voicemail_id',
+                    'voicemail_name',
                 ]
             ),
             name='call_logd_call_log_destination_details_key_check',

--- a/wazo_call_logd/database/queries/call_log.py
+++ b/wazo_call_logd/database/queries/call_log.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -80,8 +80,15 @@ class CallLogDAO(BaseDAO):
                     order_field = CallLog.date_answer
                 elif params['order'] == 'marshmallow_call_status':
                     order_field = case(
-                        (CallLog.date_answer.isnot(None), 3),
                         (CallLog.blocked.is_(True), 2),
+                        (
+                            and_(
+                                CallLog.reached_voicemail.is_(True),
+                                CallLog.date_answer.is_(None),
+                            ),
+                            3,
+                        ),
+                        (CallLog.date_answer.isnot(None), 4),
                         else_=1,
                     )
                 else:
@@ -287,6 +294,8 @@ class CallLogDAO(BaseDAO):
                 query = query.filter(CallLog.date_answer != None)  # noqa
             elif call_status == CallStatus.BLOCKED:
                 query = query.filter(CallLog.blocked == True)  # noqa
+            elif call_status == CallStatus.VOICEMAIL:
+                query = query.filter(CallLog.reached_voicemail == True)  # noqa
             elif call_status == DEFAULT_CALL_STATUS:
                 query = query.filter(
                     sql.or_(CallLog.blocked == False, CallLog.blocked == None)  # noqa

--- a/wazo_call_logd/database/queries/call_log.py
+++ b/wazo_call_logd/database/queries/call_log.py
@@ -302,6 +302,17 @@ class CallLogDAO(BaseDAO):
                     CallLog.date_answer == None,  # noqa
                     sql.or_(CallLog.blocked == False, CallLog.blocked == None),  # noqa
                 )
+            elif call_status == CallStatus.UNKNOWN:
+                # Mirror the computed call_status (CDRSchema._compute_fields):
+                # unknown only when neither answered, voicemail, nor blocked.
+                query = query.filter(
+                    CallLog.date_answer == None,  # noqa
+                    sql.or_(
+                        CallLog.reached_voicemail == False,  # noqa
+                        CallLog.reached_voicemail == None,  # noqa
+                    ),
+                    sql.or_(CallLog.blocked == False, CallLog.blocked == None),  # noqa
+                )
             elif call_status == DEFAULT_CALL_STATUS:
                 query = query.filter(
                     sql.or_(CallLog.blocked == False, CallLog.blocked == None)  # noqa

--- a/wazo_call_logd/database/queries/call_log.py
+++ b/wazo_call_logd/database/queries/call_log.py
@@ -32,7 +32,7 @@ def _status_blocked():
 
 
 def _status_answered():
-    return CallLog.date_answer.isnot(None)
+    return and_(CallLog.date_answer.isnot(None), _not_blocked())
 
 
 def _status_voicemail():

--- a/wazo_call_logd/database/queries/call_log.py
+++ b/wazo_call_logd/database/queries/call_log.py
@@ -19,6 +19,41 @@ from .base import BaseDAO
 DEFAULT_CALL_STATUS = '__default_call_status'
 
 
+# SQL mirror of the call_status computed by CDRSchema._compute_fields, so the
+# list filter and the order-by ranking below stay consistent with the value
+# actually serialized. Precedence there: blocked > voicemail > answered >
+# unknown.
+def _not_blocked():
+    return sql.or_(CallLog.blocked.is_(False), CallLog.blocked.is_(None))
+
+
+def _status_blocked():
+    return CallLog.blocked.is_(True)
+
+
+def _status_answered():
+    return CallLog.date_answer.isnot(None)
+
+
+def _status_voicemail():
+    return and_(
+        CallLog.reached_voicemail.is_(True),
+        CallLog.date_answer.is_(None),
+        _not_blocked(),
+    )
+
+
+def _status_unknown():
+    return and_(
+        CallLog.date_answer.is_(None),
+        sql.or_(
+            CallLog.reached_voicemail.is_(False),
+            CallLog.reached_voicemail.is_(None),
+        ),
+        _not_blocked(),
+    )
+
+
 class ListParams(TypedDict, total=False):
     search: str
     order: str
@@ -80,15 +115,9 @@ class CallLogDAO(BaseDAO):
                     order_field = CallLog.date_answer
                 elif params['order'] == 'marshmallow_call_status':
                     order_field = case(
-                        (CallLog.blocked.is_(True), 2),
-                        (
-                            and_(
-                                CallLog.reached_voicemail.is_(True),
-                                CallLog.date_answer.is_(None),
-                            ),
-                            3,
-                        ),
-                        (CallLog.date_answer.isnot(None), 4),
+                        (_status_blocked(), 2),
+                        (_status_voicemail(), 3),
+                        (_status_answered(), 4),
                         else_=1,
                     )
                 else:
@@ -291,32 +320,15 @@ class CallLogDAO(BaseDAO):
 
         if call_status := params.get('call_status'):
             if call_status == CallStatus.ANSWERED:
-                query = query.filter(CallLog.date_answer != None)  # noqa
+                query = query.filter(_status_answered())
             elif call_status == CallStatus.BLOCKED:
-                query = query.filter(CallLog.blocked == True)  # noqa
+                query = query.filter(_status_blocked())
             elif call_status == CallStatus.VOICEMAIL:
-                # Mirror the computed call_status (CDRSchema._compute_fields):
-                # voicemail only when the call is unanswered and not blocked.
-                query = query.filter(
-                    CallLog.reached_voicemail == True,  # noqa
-                    CallLog.date_answer == None,  # noqa
-                    sql.or_(CallLog.blocked == False, CallLog.blocked == None),  # noqa
-                )
+                query = query.filter(_status_voicemail())
             elif call_status == CallStatus.UNKNOWN:
-                # Mirror the computed call_status (CDRSchema._compute_fields):
-                # unknown only when neither answered, voicemail, nor blocked.
-                query = query.filter(
-                    CallLog.date_answer == None,  # noqa
-                    sql.or_(
-                        CallLog.reached_voicemail == False,  # noqa
-                        CallLog.reached_voicemail == None,  # noqa
-                    ),
-                    sql.or_(CallLog.blocked == False, CallLog.blocked == None),  # noqa
-                )
+                query = query.filter(_status_unknown())
             elif call_status == DEFAULT_CALL_STATUS:
-                query = query.filter(
-                    sql.or_(CallLog.blocked == False, CallLog.blocked == None)  # noqa
-                )
+                query = query.filter(_not_blocked())
 
         return query
 

--- a/wazo_call_logd/database/queries/call_log.py
+++ b/wazo_call_logd/database/queries/call_log.py
@@ -295,7 +295,13 @@ class CallLogDAO(BaseDAO):
             elif call_status == CallStatus.BLOCKED:
                 query = query.filter(CallLog.blocked == True)  # noqa
             elif call_status == CallStatus.VOICEMAIL:
-                query = query.filter(CallLog.reached_voicemail == True)  # noqa
+                # Mirror the computed call_status (CDRSchema._compute_fields):
+                # voicemail only when the call is unanswered and not blocked.
+                query = query.filter(
+                    CallLog.reached_voicemail == True,  # noqa
+                    CallLog.date_answer == None,  # noqa
+                    sql.or_(CallLog.blocked == False, CallLog.blocked == None),  # noqa
+                )
             elif call_status == DEFAULT_CALL_STATUS:
                 query = query.filter(
                     sql.or_(CallLog.blocked == False, CallLog.blocked == None)  # noqa

--- a/wazo_call_logd/datatypes.py
+++ b/wazo_call_logd/datatypes.py
@@ -1,4 +1,4 @@
-# Copyright 2023-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2023-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 """
 Type definitions and data wrappers
@@ -14,4 +14,5 @@ OrderDirection = Literal['asc', 'desc']
 class CallStatus(Enum):
     ANSWERED = 'answered'
     BLOCKED = 'blocked'
+    VOICEMAIL = 'voicemail'
     UNKNOWN = 'unknown'

--- a/wazo_call_logd/generator.py
+++ b/wazo_call_logd/generator.py
@@ -389,19 +389,24 @@ class CallLogsGenerator:
         if not call_log.reached_voicemail or call_log.date_answer:
             return
 
-        destination_details = {'type': 'voicemail'}
         voicemail = self._find_voicemail(
             call_log.voicemail_number,
             call_log.voicemail_context,
             call_log.tenant_uuid,
         )
-        if voicemail is not None:
-            destination_details['voicemail_id'] = str(voicemail['id'])
-            destination_details['voicemail_name'] = voicemail['name']
+        if voicemail is None:
+            # Unresolved (confd down, unknown mailbox): keep the interpreted
+            # details rather than dropping user attribution for a bare entry.
+            # The redirection is still surfaced by reached_voicemail/call_status.
+            return
 
-        # Only destination_details is superseded by the voicemail (the final
-        # destination of the call); the other destination_* fields are left as
-        # interpreted (e.g. the unanswered user from WAZO_CALL_LOG_DESTINATION).
+        # Supersede destination_details with the resolved voicemail; other
+        # destination_* fields are left as interpreted.
+        destination_details = {
+            'type': 'voicemail',
+            'voicemail_id': str(voicemail['id']),
+            'voicemail_name': voicemail['name'],
+        }
         call_log.destination_details = [
             Destination(
                 destination_details_key=key,

--- a/wazo_call_logd/generator.py
+++ b/wazo_call_logd/generator.py
@@ -433,7 +433,7 @@ class CallLogsGenerator:
                 tenant_uuid=tenant_uuid,
             )['items']
         except requests.exceptions.RequestException as e:
-            logger.exception(
+            logger.error(
                 'Failed to fetch voicemail %s@%s from confd: %s', number, context, e
             )
             return None

--- a/wazo_call_logd/generator.py
+++ b/wazo_call_logd/generator.py
@@ -425,9 +425,6 @@ class CallLogsGenerator:
         key = (number, context, tenant_uuid)
         if cache is not None and key in cache:
             return cache[key]
-        # Best-effort enrichment: never drop the call log if confd fails.
-        # Scope to the call log's tenant, else recurse=True spans every tenant
-        # and a context-less number could leak another tenant's voicemail.
         try:
             voicemails = self.confd.voicemails.list(
                 number=number,
@@ -436,10 +433,7 @@ class CallLogsGenerator:
                 tenant_uuid=tenant_uuid,
             )['items']
         except requests.exceptions.RequestException as e:
-            # Catch any confd request failure (HTTP error, timeout, connection
-            # error): the lookup is best-effort and must not drop the call log.
-            # Not cached: a transient failure must not poison later lookups.
-            logger.error(
+            logger.exception(
                 'Failed to fetch voicemail %s@%s from confd: %s', number, context, e
             )
             return None

--- a/wazo_call_logd/generator.py
+++ b/wazo_call_logd/generator.py
@@ -384,7 +384,9 @@ class CallLogsGenerator:
                 )
 
     def _resolve_voicemail_destination(self, call_log: RawCallLog):
-        if not call_log.reached_voicemail:
+        # Voicemail is the destination only when unanswered (mirrors the
+        # computed call_status); answered calls keep their interpreted details.
+        if not call_log.reached_voicemail or call_log.date_answer:
             return
 
         destination_details = {'type': 'voicemail'}

--- a/wazo_call_logd/generator.py
+++ b/wazo_call_logd/generator.py
@@ -437,6 +437,16 @@ class CallLogsGenerator:
                 'Failed to fetch voicemail %s@%s from confd: %s', number, context, e
             )
             return None
+        if len(voicemails) > 1:
+            # Only reachable when the CEL mailbox had no @context.
+            logger.warning(
+                'Found %s voicemails matching %s@%s (ids=%s), '
+                'attributing the call to the first one',
+                len(voicemails),
+                number,
+                context,
+                [candidate['id'] for candidate in voicemails],
+            )
         voicemail = voicemails[0] if voicemails else None
         if voicemail is None:
             logger.debug('No voicemail found for %s@%s', number, context)

--- a/wazo_call_logd/generator.py
+++ b/wazo_call_logd/generator.py
@@ -384,7 +384,7 @@ class CallLogsGenerator:
                     call_log.requested_internal_context,
                 )
 
-    def _resolve_voicemail_destination(self, call_log: RawCallLog, cache=None):
+    def _resolve_voicemail_destination(self, call_log: RawCallLog, cache: dict):
         # Voicemail is the destination only when unanswered (mirrors the
         # computed call_status); answered calls keep their interpreted details.
         if not call_log.reached_voicemail or call_log.date_answer:
@@ -417,13 +417,13 @@ class CallLogsGenerator:
             for key, value in destination_details.items()
         ]
 
-    def _find_voicemail(self, number, context, tenant_uuid, cache=None):
+    def _find_voicemail(self, number, context, tenant_uuid, cache: dict):
         if not number:
             return None
         # Memoize per batch: a run regenerating many calls to the same mailbox
         # would otherwise issue one identical confd request per call log.
         key = (number, context, tenant_uuid)
-        if cache is not None and key in cache:
+        if key in cache:
             return cache[key]
         try:
             voicemails = self.confd.voicemails.list(
@@ -440,8 +440,7 @@ class CallLogsGenerator:
         voicemail = voicemails[0] if voicemails else None
         if voicemail is None:
             logger.debug('No voicemail found for %s@%s', number, context)
-        if cache is not None:
-            cache[key] = voicemail
+        cache[key] = voicemail
         return voicemail
 
     def _remove_incomplete_recordings(self, call_log: RawCallLog):

--- a/wazo_call_logd/generator.py
+++ b/wazo_call_logd/generator.py
@@ -389,7 +389,9 @@ class CallLogsGenerator:
 
         destination_details = {'type': 'voicemail'}
         voicemail = self._find_voicemail(
-            call_log.voicemail_number, call_log.voicemail_context
+            call_log.voicemail_number,
+            call_log.voicemail_context,
+            call_log.tenant_uuid,
         )
         if voicemail is not None:
             destination_details['voicemail_id'] = str(voicemail['id'])
@@ -406,17 +408,18 @@ class CallLogsGenerator:
             for key, value in destination_details.items()
         ]
 
-    def _find_voicemail(self, number, context):
+    def _find_voicemail(self, number, context, tenant_uuid):
         if not number:
             return None
-        # The "reached voicemail" fact comes from the CEL alone; resolving the
-        # voicemail name/id is best-effort enrichment and must not drop the
-        # call log if confd is unreachable or lacks the endpoint.
+        # Best-effort enrichment: never drop the call log if confd fails.
+        # Scope to the call log's tenant, else recurse=True spans every tenant
+        # and a context-less number could leak another tenant's voicemail.
         try:
             voicemails = self.confd.voicemails.list(
                 number=number,
                 context=context,
                 recurse=True,
+                tenant_uuid=tenant_uuid,
             )['items']
         except requests.exceptions.RequestException as e:
             # Catch any confd request failure (HTTP error, timeout, connection

--- a/wazo_call_logd/generator.py
+++ b/wazo_call_logd/generator.py
@@ -418,7 +418,9 @@ class CallLogsGenerator:
                 context=context,
                 recurse=True,
             )['items']
-        except requests.exceptions.HTTPError as e:
+        except requests.exceptions.RequestException as e:
+            # Catch any confd request failure (HTTP error, timeout, connection
+            # error): the lookup is best-effort and must not drop the call log.
             logger.error(
                 'Failed to fetch voicemail %s@%s from confd: %s', number, context, e
             )

--- a/wazo_call_logd/generator.py
+++ b/wazo_call_logd/generator.py
@@ -9,6 +9,7 @@ from collections.abc import Iterator
 from itertools import groupby
 from operator import attrgetter
 
+import requests.exceptions
 from wazo_confd_client import Client as ConfdClient
 from xivo.asterisk.protocol_interface import protocol_interface_from_channel
 from xivo_dao.alchemy.cel import CEL
@@ -18,7 +19,7 @@ from wazo_call_logd.database.cel_event_type import CELEventType
 from wazo_call_logd.exceptions import InvalidCallLogException
 from wazo_call_logd.raw_call_log import RawCallLog
 
-from .database.models import CallLog, CallLogParticipant
+from .database.models import CallLog, CallLogParticipant, Destination
 from .participant import ParticipantInfo, find_participant, find_participant_by_uuid
 
 logger = logging.getLogger(__name__)
@@ -256,6 +257,7 @@ class CallLogsGenerator:
                 self._fetch_participants(call_log)
                 self._ensure_tenant_uuid_is_set(call_log)
                 self._fill_extensions_from_participants(call_log)
+                self._resolve_voicemail_destination(call_log)
                 self._remove_incomplete_recordings(call_log)
                 self._remove_recordings_for_unanswered_calls(call_log)
                 self._handle_recording_pauses(call_log)
@@ -380,6 +382,51 @@ class CallLogsGenerator:
                     call_log.requested_internal_exten,
                     call_log.requested_internal_context,
                 )
+
+    def _resolve_voicemail_destination(self, call_log: RawCallLog):
+        if not call_log.reached_voicemail:
+            return
+
+        destination_details = {'type': 'voicemail'}
+        voicemail = self._find_voicemail(
+            call_log.voicemail_number, call_log.voicemail_context
+        )
+        if voicemail is not None:
+            destination_details['voicemail_id'] = str(voicemail['id'])
+            destination_details['voicemail_name'] = voicemail['name']
+
+        # Only destination_details is superseded by the voicemail (the final
+        # destination of the call); the other destination_* fields are left as
+        # interpreted (e.g. the unanswered user from WAZO_CALL_LOG_DESTINATION).
+        call_log.destination_details = [
+            Destination(
+                destination_details_key=key,
+                destination_details_value=value,
+            )
+            for key, value in destination_details.items()
+        ]
+
+    def _find_voicemail(self, number, context):
+        if not number:
+            return None
+        # The "reached voicemail" fact comes from the CEL alone; resolving the
+        # voicemail name/id is best-effort enrichment and must not drop the
+        # call log if confd is unreachable or lacks the endpoint.
+        try:
+            voicemails = self.confd.voicemails.list(
+                number=number,
+                context=context,
+                recurse=True,
+            )['items']
+        except requests.exceptions.HTTPError as e:
+            logger.error(
+                'Failed to fetch voicemail %s@%s from confd: %s', number, context, e
+            )
+            return None
+        if not voicemails:
+            logger.debug('No voicemail found for %s@%s', number, context)
+            return None
+        return voicemails[0]
 
     def _remove_incomplete_recordings(self, call_log: RawCallLog):
         new_recordings = []

--- a/wazo_call_logd/generator.py
+++ b/wazo_call_logd/generator.py
@@ -220,6 +220,7 @@ class CallLogsGenerator:
 
     def call_logs_from_cel(self, cels: list[CEL]) -> list[CallLog]:
         result = []
+        voicemail_cache: dict = {}
         for linkedids, cels_by_call in _group_cels_by_shared_channels(cels):
             logger.debug(
                 'interpreting %d cels from correlated linkedids(%s)',
@@ -257,7 +258,7 @@ class CallLogsGenerator:
                 self._fetch_participants(call_log)
                 self._ensure_tenant_uuid_is_set(call_log)
                 self._fill_extensions_from_participants(call_log)
-                self._resolve_voicemail_destination(call_log)
+                self._resolve_voicemail_destination(call_log, voicemail_cache)
                 self._remove_incomplete_recordings(call_log)
                 self._remove_recordings_for_unanswered_calls(call_log)
                 self._handle_recording_pauses(call_log)
@@ -383,7 +384,7 @@ class CallLogsGenerator:
                     call_log.requested_internal_context,
                 )
 
-    def _resolve_voicemail_destination(self, call_log: RawCallLog):
+    def _resolve_voicemail_destination(self, call_log: RawCallLog, cache=None):
         # Voicemail is the destination only when unanswered (mirrors the
         # computed call_status); answered calls keep their interpreted details.
         if not call_log.reached_voicemail or call_log.date_answer:
@@ -393,6 +394,7 @@ class CallLogsGenerator:
             call_log.voicemail_number,
             call_log.voicemail_context,
             call_log.tenant_uuid,
+            cache,
         )
         if voicemail is None:
             # Unresolved (confd down, unknown mailbox): keep the interpreted
@@ -415,9 +417,14 @@ class CallLogsGenerator:
             for key, value in destination_details.items()
         ]
 
-    def _find_voicemail(self, number, context, tenant_uuid):
+    def _find_voicemail(self, number, context, tenant_uuid, cache=None):
         if not number:
             return None
+        # Memoize per batch: a run regenerating many calls to the same mailbox
+        # would otherwise issue one identical confd request per call log.
+        key = (number, context, tenant_uuid)
+        if cache is not None and key in cache:
+            return cache[key]
         # Best-effort enrichment: never drop the call log if confd fails.
         # Scope to the call log's tenant, else recurse=True spans every tenant
         # and a context-less number could leak another tenant's voicemail.
@@ -431,14 +438,17 @@ class CallLogsGenerator:
         except requests.exceptions.RequestException as e:
             # Catch any confd request failure (HTTP error, timeout, connection
             # error): the lookup is best-effort and must not drop the call log.
+            # Not cached: a transient failure must not poison later lookups.
             logger.error(
                 'Failed to fetch voicemail %s@%s from confd: %s', number, context, e
             )
             return None
-        if not voicemails:
+        voicemail = voicemails[0] if voicemails else None
+        if voicemail is None:
             logger.debug('No voicemail found for %s@%s', number, context)
-            return None
-        return voicemails[0]
+        if cache is not None:
+            cache[key] = voicemail
+        return voicemail
 
     def _remove_incomplete_recordings(self, call_log: RawCallLog):
         new_recordings = []

--- a/wazo_call_logd/plugins/cdr/api.yml
+++ b/wazo_call_logd/plugins/cdr/api.yml
@@ -427,6 +427,7 @@ parameters:
       - answered
       - blocked
       - voicemail
+      - unknown
     in: query
 definitions:
   call_status:
@@ -503,7 +504,7 @@ definitions:
         type: string
       destination_details:
         type: object
-        description: Contains the `type` of the called destination; which can be either `user`, `conference`, `meeting`, `group` or `unknown` by default. Also contains useful information about the destination (`id` and `name`).
+        description: Contains the `type` of the called destination; which can be either `user`, `conference`, `meeting`, `group`, `voicemail` or `unknown` by default. Also contains useful information about the destination (`id` and `name`). A call that was redirected to a voicemail and not answered reports `type` `voicemail`, even when the call was originally placed to a user; the user remains available in `destination_user_uuid`.
       destination_name:
         type: string
         description: name of the party that answered the call

--- a/wazo_call_logd/plugins/cdr/api.yml
+++ b/wazo_call_logd/plugins/cdr/api.yml
@@ -426,6 +426,7 @@ parameters:
     enum:
       - answered
       - blocked
+      - voicemail
     in: query
 definitions:
   call_status:
@@ -433,6 +434,7 @@ definitions:
     enum:
       - answered
       - blocked
+      - voicemail
       - unknown
   CDRList:
     type: object

--- a/wazo_call_logd/plugins/cdr/schemas.py
+++ b/wazo_call_logd/plugins/cdr/schemas.py
@@ -170,6 +170,9 @@ class CDRSchema(Schema):
         if data.date_answer and data.date_end:
             data.marshmallow_duration = data.date_end - data.date_answer
 
+        # Canonical call_status definition. The SQL predicates in
+        # database/queries/call_log.py mirror this for filtering and ordering;
+        # keep them in sync. Precedence: blocked > voicemail > answered.
         data.marshmallow_call_status = CallStatus.UNKNOWN.value
         if data.marshmallow_answered:
             data.marshmallow_call_status = CallStatus.ANSWERED.value

--- a/wazo_call_logd/plugins/cdr/schemas.py
+++ b/wazo_call_logd/plugins/cdr/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from marshmallow import EXCLUDE, post_dump, post_load, pre_dump, pre_load
@@ -89,6 +89,11 @@ class DestinationGroupDetails(BaseDestinationDetailsSchema):
     group_id = fields.Integer()
 
 
+class DestinationVoicemailDetails(BaseDestinationDetailsSchema):
+    voicemail_id = fields.Integer()
+    voicemail_name = fields.String()
+
+
 class DestinationDetailsField(fields.Nested):
     destination_details_schemas = {
         'conference': DestinationConferenceDetails,
@@ -96,6 +101,7 @@ class DestinationDetailsField(fields.Nested):
         'user': DestinationUserDetails,
         'unknown': DestinationUnknownDetails,
         'group': DestinationGroupDetails,
+        'voicemail': DestinationVoicemailDetails,
     }
 
     def __init__(self, *args, **kwargs):
@@ -167,6 +173,8 @@ class CDRSchema(Schema):
         data.marshmallow_call_status = CallStatus.UNKNOWN.value
         if data.marshmallow_answered:
             data.marshmallow_call_status = CallStatus.ANSWERED.value
+        if data.reached_voicemail and not data.marshmallow_answered:
+            data.marshmallow_call_status = CallStatus.VOICEMAIL.value
         if data.blocked:
             data.marshmallow_call_status = CallStatus.BLOCKED.value
         return data

--- a/wazo_call_logd/plugins/cdr/tests/__init__.py
+++ b/wazo_call_logd/plugins/cdr/tests/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later

--- a/wazo_call_logd/plugins/cdr/tests/__init__.py
+++ b/wazo_call_logd/plugins/cdr/tests/__init__.py
@@ -1,2 +1,0 @@
-# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
-# SPDX-License-Identifier: GPL-3.0-or-later

--- a/wazo_call_logd/plugins/cdr/tests/test_schemas.py
+++ b/wazo_call_logd/plugins/cdr/tests/test_schemas.py
@@ -1,0 +1,37 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from datetime import datetime
+from unittest import TestCase
+
+from hamcrest import assert_that, has_entries
+
+from wazo_call_logd.database.models import CallLog
+
+from ..schemas import CDRSchema
+
+
+class TestCDRSchemaCallStatus(TestCase):
+    def _dump(self, **kwargs):
+        call_log = CallLog(date=datetime(2024, 1, 1, 10, 0, 0), **kwargs)
+        return CDRSchema().dump(call_log)
+
+    def test_unknown_when_not_answered_not_voicemail_not_blocked(self):
+        result = self._dump(date_answer=None, reached_voicemail=False, blocked=False)
+        assert_that(result, has_entries(call_status='unknown', answered=False))
+
+    def test_answered_when_date_answer_set(self):
+        result = self._dump(
+            date_answer=datetime(2024, 1, 1, 10, 0, 5),
+            reached_voicemail=False,
+            blocked=False,
+        )
+        assert_that(result, has_entries(call_status='answered', answered=True))
+
+    def test_voicemail_when_reached_voicemail_and_not_answered(self):
+        result = self._dump(date_answer=None, reached_voicemail=True, blocked=False)
+        assert_that(result, has_entries(call_status='voicemail', answered=False))
+
+    def test_blocked_supersedes_voicemail(self):
+        result = self._dump(date_answer=None, reached_voicemail=True, blocked=True)
+        assert_that(result, has_entries(call_status='blocked'))

--- a/wazo_call_logd/raw_call_log.py
+++ b/wazo_call_logd/raw_call_log.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -70,6 +70,9 @@ class RawCallLog:
         self.destination_details: list = []
         self.was_forwarded: bool = False
         self.blocked: bool = False
+        self.reached_voicemail: bool = False
+        self.voicemail_number: str | None = None
+        self.voicemail_context: str | None = None
 
     @property
     def tenant_uuid(self) -> str:
@@ -117,6 +120,7 @@ class RawCallLog:
             destination_details=self.destination_details,
             conversation_id=self.conversation_id,
             blocked=self.blocked,
+            reached_voicemail=self.reached_voicemail,
         )
         result.participants = self.participants
         result.cel_ids = self.cel_ids

--- a/wazo_call_logd/tests/test_cel_interpretor.py
+++ b/wazo_call_logd/tests/test_cel_interpretor.py
@@ -26,6 +26,7 @@ from ..cel_interpretor import (
     CalleeCELInterpretor,
     CallerCELInterpretor,
     DispatchCELInterpretor,
+    LocalOriginateCELInterpretor,
     _extract_user_missed_call_variables,
     _parse_wazo_originate_all_lines_extra,
     bridge_info,
@@ -755,3 +756,46 @@ class TestCalleeCELInterpretor(TestCase):
         self.interpretor.interpret_cel(cel, call)
 
         assert_that(call.reached_voicemail, equal_to(False))
+
+
+class TestLocalOriginateCELInterpretor(TestCase):
+    def setUp(self):
+        self.interpretor = LocalOriginateCELInterpretor()
+
+    def _cel(self, eventtype, uniqueid, **kwargs):
+        when = datetime(2026, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+        defaults = {
+            'eventtype': eventtype,
+            'uniqueid': uniqueid,
+            'eventtime': when,
+            'cid_name': '',
+            'cid_num': '',
+            'channame': f'PJSIP/{uniqueid}-00000001',
+        }
+        defaults.update(kwargs)
+        return Mock(**defaults)
+
+    def test_originated_call_to_voicemail_sets_reached_voicemail(self):
+        # A click-to-call/API-originated call (local channel pair + source +
+        # destination) that ends in voicemail runs VoiceMail() on one of its
+        # channels; it must be detected like the caller/callee paths.
+        cels = [
+            self._cel('CHAN_START', 'local1', channame='Local/1@a-00000001;1'),
+            self._cel('CHAN_START', 'local2', channame='Local/1@a-00000001;2'),
+            self._cel('CHAN_START', 'source', cid_name='Bob', cid_num='1006'),
+            self._cel('ANSWER', 'source', cid_name='Bob', cid_num='1006'),
+            self._cel('ANSWER', 'local2', cid_num='1006'),
+            self._cel(
+                'APP_START', 'dest', appname='VoiceMail', appdata='1006@default,u'
+            ),
+            self._cel('CHAN_END', 'source'),
+        ]
+        call = RawCallLog()
+
+        self.interpretor.interpret_cels(cels, call)
+
+        assert_that(call.reached_voicemail, equal_to(True))
+        assert_that(call.voicemail_number, equal_to('1006'))
+        assert_that(call.voicemail_context, equal_to('default'))
+        # no destination answered, so the call stays unanswered (voicemail)
+        assert_that(call.date_answer, equal_to(None))

--- a/wazo_call_logd/tests/test_cel_interpretor.py
+++ b/wazo_call_logd/tests/test_cel_interpretor.py
@@ -757,6 +757,23 @@ class TestCalleeCELInterpretor(TestCase):
 
         assert_that(call.reached_voicemail, equal_to(False))
 
+    def test_interpret_app_start_multi_mailbox_uses_first(self):
+        # A custom dialplan may pass Asterisk's "&"-separated multi-mailbox
+        # syntax; the CDR is attributed to the first mailbox, not a garbage
+        # context.
+        cel = Mock(
+            eventtype=CELEventType.app_start,
+            appname='VoiceMail',
+            appdata='1001@default&1002@other,u',
+        )
+        call = RawCallLog()
+
+        self.interpretor.interpret_cel(cel, call)
+
+        assert_that(call.reached_voicemail, equal_to(True))
+        assert_that(call.voicemail_number, equal_to('1001'))
+        assert_that(call.voicemail_context, equal_to('default'))
+
 
 class TestLocalOriginateCELInterpretor(TestCase):
     def setUp(self):

--- a/wazo_call_logd/tests/test_cel_interpretor.py
+++ b/wazo_call_logd/tests/test_cel_interpretor.py
@@ -727,3 +727,31 @@ class TestCalleeCELInterpretor(TestCase):
         self.interpretor.interpret_chan_end(Mock(eventtime=chan_end_time), call)
 
         assert_that(recording.end_time, equal_to(mixmonitor_stop_time))
+
+    def test_interpret_app_start_voicemail_sets_reached_voicemail(self):
+        # A VoiceMail() on the callee channel (e.g. blind transfer to voicemail)
+        # must be detected, since it is dispatched to the callee interpretor.
+        cel = Mock(
+            eventtype=CELEventType.app_start,
+            appname='VoiceMail',
+            appdata='1006@default,u',
+        )
+        call = RawCallLog()
+
+        self.interpretor.interpret_cel(cel, call)
+
+        assert_that(call.reached_voicemail, equal_to(True))
+        assert_that(call.voicemail_number, equal_to('1006'))
+        assert_that(call.voicemail_context, equal_to('default'))
+
+    def test_interpret_app_start_voicemailmain_not_a_redirection(self):
+        cel = Mock(
+            eventtype=CELEventType.app_start,
+            appname='VoiceMailMain',
+            appdata='1006@default',
+        )
+        call = RawCallLog()
+
+        self.interpretor.interpret_cel(cel, call)
+
+        assert_that(call.reached_voicemail, equal_to(False))

--- a/wazo_call_logd/tests/test_generator.py
+++ b/wazo_call_logd/tests/test_generator.py
@@ -593,6 +593,51 @@ class TestResolveVoicemailDestination(TestCase):
             ),
         )
 
+    def test_confd_failure_keeps_interpreted_destination_details(self):
+        # confd unreachable: keep the interpreted user destination_details
+        # instead of overwriting the only user attribution with a bare entry.
+        self.confd.voicemails.list.side_effect = requests.exceptions.ConnectionError(
+            'confd unreachable'
+        )
+        call_log = self._voicemail_call_log()
+
+        self.generator._resolve_voicemail_destination(call_log)
+
+        assert_that(
+            call_log.destination_details,
+            contains_inanyorder(
+                has_properties(
+                    destination_details_key='type',
+                    destination_details_value='user',
+                ),
+                has_properties(
+                    destination_details_key='user_uuid',
+                    destination_details_value=self.USER_UUID,
+                ),
+            ),
+        )
+
+    def test_unknown_mailbox_keeps_interpreted_destination_details(self):
+        # confd reachable but the mailbox is unknown: same preservation.
+        self.confd.voicemails.list.return_value = {'items': []}
+        call_log = self._voicemail_call_log()
+
+        self.generator._resolve_voicemail_destination(call_log)
+
+        assert_that(
+            call_log.destination_details,
+            contains_inanyorder(
+                has_properties(
+                    destination_details_key='type',
+                    destination_details_value='user',
+                ),
+                has_properties(
+                    destination_details_key='user_uuid',
+                    destination_details_value=self.USER_UUID,
+                ),
+            ),
+        )
+
     def test_answered_call_keeps_interpreted_destination_details(self):
         # A call that reached voicemail but was ultimately answered (voicemail
         # escape then operator) has computed call_status 'answered', so its

--- a/wazo_call_logd/tests/test_generator.py
+++ b/wazo_call_logd/tests/test_generator.py
@@ -48,6 +48,7 @@ def mock_call():
         participants=[],
         participants_info=[],
         date_answer=None,
+        reached_voicemail=False,
     )
 
 
@@ -210,6 +211,7 @@ class TestCallLogsGenerator(TestCase):
         sequence_2 = self._generate_cels_for_call('123456789.1')
         sequence_2[0].uniqueid = sequence_1[0].uniqueid
 
+        call_log_constructor.return_value.reached_voicemail = False
         self.interpretor.interpret_cels.side_effect = lambda cels, call: call
         call_logs = self.generator.call_logs_from_cel(sequence_1 + sequence_2)
         assert call_logs
@@ -222,6 +224,7 @@ class TestCallLogsGenerator(TestCase):
         sequence_1 = self._generate_cels_for_call('123456789.0')
         sequence_2 = self._generate_cels_for_call('123456789.1')
 
+        call_log_constructor.return_value.reached_voicemail = False
         self.interpretor.interpret_cels.side_effect = lambda cels, call: call
         call_logs = self.generator.call_logs_from_cel(sequence_1 + sequence_2)
         assert call_logs

--- a/wazo_call_logd/tests/test_generator.py
+++ b/wazo_call_logd/tests/test_generator.py
@@ -29,7 +29,7 @@ from hamcrest import (
 from xivo_dao.alchemy.cel import CEL
 
 from wazo_call_logd.database.cel_event_type import CELEventType
-from wazo_call_logd.database.models import Recording
+from wazo_call_logd.database.models import Destination, Recording
 from wazo_call_logd.exceptions import InvalidCallLogException
 from wazo_call_logd.generator import (
     CallLogsGenerator,
@@ -537,6 +537,85 @@ class TestFillExtensionsFromParticipants(TestCase):
 
         assert_that(call_log.destination_internal_exten, none())
         assert_that(call_log.destination_internal_context, none())
+
+
+class TestResolveVoicemailDestination(TestCase):
+    TENANT_UUID = '54eb71f8-1f4b-4ae4-8730-638062fbe521'
+    USER_UUID = 'cb79f29b-f69a-4b93-85c2-49dcce119a9f'
+
+    def setUp(self):
+        self.confd = Mock()
+        self.generator = CallLogsGenerator(self.confd, [Mock()])
+
+    def _user_destination(self):
+        return [
+            Destination(
+                destination_details_key='type', destination_details_value='user'
+            ),
+            Destination(
+                destination_details_key='user_uuid',
+                destination_details_value=self.USER_UUID,
+            ),
+        ]
+
+    def _voicemail_call_log(self):
+        call_log = RawCallLog()
+        call_log.set_tenant_uuid(self.TENANT_UUID)
+        call_log.reached_voicemail = True
+        call_log.voicemail_number = '1006'
+        call_log.voicemail_context = 'default'
+        call_log.destination_details = self._user_destination()
+        return call_log
+
+    def test_unanswered_voicemail_supersedes_destination_details(self):
+        self.confd.voicemails.list.return_value = {
+            'items': [{'id': 7, 'name': 'Harry VM'}]
+        }
+        call_log = self._voicemail_call_log()
+
+        self.generator._resolve_voicemail_destination(call_log)
+
+        assert_that(
+            call_log.destination_details,
+            contains_inanyorder(
+                has_properties(
+                    destination_details_key='type',
+                    destination_details_value='voicemail',
+                ),
+                has_properties(
+                    destination_details_key='voicemail_id',
+                    destination_details_value='7',
+                ),
+                has_properties(
+                    destination_details_key='voicemail_name',
+                    destination_details_value='Harry VM',
+                ),
+            ),
+        )
+
+    def test_answered_call_keeps_interpreted_destination_details(self):
+        # A call that reached voicemail but was ultimately answered (voicemail
+        # escape then operator) has computed call_status 'answered', so its
+        # interpreted destination_details must be preserved, not overwritten.
+        call_log = self._voicemail_call_log()
+        call_log.date_answer = datetime.fromisoformat('2024-05-07 20:01:05+00:00')
+
+        self.generator._resolve_voicemail_destination(call_log)
+
+        self.confd.voicemails.list.assert_not_called()
+        assert_that(
+            call_log.destination_details,
+            contains_inanyorder(
+                has_properties(
+                    destination_details_key='type',
+                    destination_details_value='user',
+                ),
+                has_properties(
+                    destination_details_key='user_uuid',
+                    destination_details_value=self.USER_UUID,
+                ),
+            ),
+        )
 
 
 class TestRemoveRecordingsForUnansweredCalls(TestCase):

--- a/wazo_call_logd/tests/test_generator.py
+++ b/wazo_call_logd/tests/test_generator.py
@@ -638,6 +638,54 @@ class TestResolveVoicemailDestination(TestCase):
             ),
         )
 
+    def test_cache_collapses_repeated_lookups_into_one_confd_call(self):
+        # A batch of call logs hitting the same mailbox must issue a single
+        # confd request, not one per call log.
+        self.confd.voicemails.list.return_value = {
+            'items': [{'id': 7, 'name': 'Harry VM'}]
+        }
+        cache: dict = {}
+
+        for _ in range(3):
+            self.generator._resolve_voicemail_destination(
+                self._voicemail_call_log(), cache
+            )
+
+        self.confd.voicemails.list.assert_called_once()
+
+    def test_transient_confd_failure_is_not_cached(self):
+        # A request failure must not poison the cache: a later call to the same
+        # mailbox retries confd.
+        self.confd.voicemails.list.side_effect = [
+            requests.exceptions.ConnectionError('confd unreachable'),
+            {'items': [{'id': 7, 'name': 'Harry VM'}]},
+        ]
+        cache: dict = {}
+
+        first = self._voicemail_call_log()
+        self.generator._resolve_voicemail_destination(first, cache)
+        second = self._voicemail_call_log()
+        self.generator._resolve_voicemail_destination(second, cache)
+
+        assert_that(self.confd.voicemails.list.call_count, equal_to(2))
+        assert_that(
+            second.destination_details,
+            contains_inanyorder(
+                has_properties(
+                    destination_details_key='type',
+                    destination_details_value='voicemail',
+                ),
+                has_properties(
+                    destination_details_key='voicemail_id',
+                    destination_details_value='7',
+                ),
+                has_properties(
+                    destination_details_key='voicemail_name',
+                    destination_details_value='Harry VM',
+                ),
+            ),
+        )
+
     def test_answered_call_keeps_interpreted_destination_details(self):
         # A call that reached voicemail but was ultimately answered (voicemail
         # escape then operator) has computed call_status 'answered', so its

--- a/wazo_call_logd/tests/test_generator.py
+++ b/wazo_call_logd/tests/test_generator.py
@@ -573,7 +573,7 @@ class TestResolveVoicemailDestination(TestCase):
         }
         call_log = self._voicemail_call_log()
 
-        self.generator._resolve_voicemail_destination(call_log)
+        self.generator._resolve_voicemail_destination(call_log, {})
 
         assert_that(
             call_log.destination_details,
@@ -601,7 +601,7 @@ class TestResolveVoicemailDestination(TestCase):
         )
         call_log = self._voicemail_call_log()
 
-        self.generator._resolve_voicemail_destination(call_log)
+        self.generator._resolve_voicemail_destination(call_log, {})
 
         assert_that(
             call_log.destination_details,
@@ -622,7 +622,7 @@ class TestResolveVoicemailDestination(TestCase):
         self.confd.voicemails.list.return_value = {'items': []}
         call_log = self._voicemail_call_log()
 
-        self.generator._resolve_voicemail_destination(call_log)
+        self.generator._resolve_voicemail_destination(call_log, {})
 
         assert_that(
             call_log.destination_details,
@@ -693,7 +693,7 @@ class TestResolveVoicemailDestination(TestCase):
         call_log = self._voicemail_call_log()
         call_log.date_answer = datetime.fromisoformat('2024-05-07 20:01:05+00:00')
 
-        self.generator._resolve_voicemail_destination(call_log)
+        self.generator._resolve_voicemail_destination(call_log, {})
 
         self.confd.voicemails.list.assert_not_called()
         assert_that(

--- a/wazo_call_logd/tests/test_generator_scenarios.py
+++ b/wazo_call_logd/tests/test_generator_scenarios.py
@@ -188,13 +188,25 @@ def mock_context(id: int, name: str, tenant_uuid: str) -> dict[str, int | str]:
     return mock_dict({'id': id, 'name': name, 'tenant_uuid': tenant_uuid})
 
 
+def mock_voicemail(
+    id: int, name: str, number: str, context: str
+) -> dict[str, int | str]:
+    return mock_dict({'id': id, 'name': name, 'number': number, 'context': context})
+
+
 def mock_confd_client(
     lines: list[dict] = None,
     users: list[dict] = None,
     contexts: list[dict] = None,
+    voicemails: list[dict] = None,
 ) -> ConfdClient:
     confd_client = create_autospec(
-        ConfdClient, instance=True, lines=Mock(), users=Mock(), contexts=Mock()
+        ConfdClient,
+        instance=True,
+        lines=Mock(),
+        users=Mock(),
+        contexts=Mock(),
+        voicemails=Mock(),
     )
 
     def list_lines(name=None, **kwargs):
@@ -228,6 +240,20 @@ def mock_confd_client(
         return {'items': filtered_contexts}
 
     confd_client.contexts.list.side_effect = list_contexts
+
+    def list_voicemails(number=None, context=None, **kwargs):
+        if voicemails is None:
+            filtered_voicemails = []
+        else:
+            filtered_voicemails = [
+                voicemail
+                for voicemail in voicemails
+                if (number is None or voicemail['number'] == number)
+                and (context is None or voicemail['context'] == context)
+            ]
+        return {'items': filtered_voicemails}
+
+    confd_client.voicemails.list.side_effect = list_voicemails
     return confd_client
 
 
@@ -246,6 +272,121 @@ class TestCallLogGenerationScenarios(TestCase):
             self.confd_client,
             default_interpretors(),
         )
+
+    @raw_cels(
+        '''
+        eventtype    | eventtime                     | cid_name      | cid_num       | exten | context     | channame                | appname         | appdata                                          | linkedid     | uniqueid     | extra
+        CHAN_START   | 2024-05-07 20:00:00.000000+00 | +12345678910  | +12345678910  | 1001  | from-extern | PJSIP/2c70p24m-00000001 |                 |                                                  | 1715000000.1 | 1715000000.1 |
+        XIVO_INCALL  | 2024-05-07 20:00:00.500000+00 | 0012345678910 | 0012345678910 | s     | did         | PJSIP/2c70p24m-00000001 | CELGenUserEvent | XIVO_INCALL,54eb71f8-1f4b-4ae4-8730-638062fbe521 | 1715000000.1 | 1715000000.1 | {"extra":"54eb71f8-1f4b-4ae4-8730-638062fbe521"}
+        APP_START    | 2024-05-07 20:00:01.000000+00 | 0012345678910 | 0012345678910 | s     | user        | PJSIP/2c70p24m-00000001 | Voicemail       | 1001@default,u                                   | 1715000000.1 | 1715000000.1 |
+        HANGUP       | 2024-05-07 20:00:05.000000+00 | 0012345678910 | 0012345678910 | s     | user        | PJSIP/2c70p24m-00000001 |                 |                                                  | 1715000000.1 | 1715000000.1 | {"hangupcause":16,"hangupsource":"","dialstatus":""}
+        CHAN_END     | 2024-05-07 20:00:05.000000+00 | 0012345678910 | 0012345678910 | s     | user        | PJSIP/2c70p24m-00000001 |                 |                                                  | 1715000000.1 | 1715000000.1 |
+        LINKEDID_END | 2024-05-07 20:00:05.000000+00 | 0012345678910 | 0012345678910 | s     | user        | PJSIP/2c70p24m-00000001 |                 |                                                  | 1715000000.1 | 1715000000.1 |
+        '''
+    )
+    def test_incoming_call_directly_to_voicemail(self, cels):
+        self.generator.confd = mock_confd_client(
+            voicemails=[
+                mock_voicemail(id=42, name='Bob VM', number='1001', context='default')
+            ],
+        )
+
+        call_logs = self.generator.call_logs_from_cel(cels)
+        assert len(call_logs) == 1
+
+        assert_that(
+            call_logs[0],
+            has_properties(
+                reached_voicemail=True,
+                date_answer=None,
+                # destination_name is left as interpreted, not the voicemail name
+                destination_name=None,
+                destination_details=contains_inanyorder(
+                    has_properties(
+                        destination_details_key='type',
+                        destination_details_value='voicemail',
+                    ),
+                    has_properties(
+                        destination_details_key='voicemail_id',
+                        destination_details_value='42',
+                    ),
+                    has_properties(
+                        destination_details_key='voicemail_name',
+                        destination_details_value='Bob VM',
+                    ),
+                ),
+            ),
+        )
+
+    @raw_cels(
+        '''
+        eventtype                 | eventtime                     | cid_name      | cid_num       | exten | context     | channame                | appname         | appdata                                                              | linkedid     | uniqueid     | extra
+        CHAN_START                | 2024-05-07 20:01:00.000000+00 | +12345678910  | +12345678910  | 1006  | from-extern | PJSIP/2c70p24m-00000002 |                 |                                                                      | 1715000100.2 | 1715000100.2 |
+        XIVO_INCALL               | 2024-05-07 20:01:00.500000+00 | 0012345678910 | 0012345678910 | s     | did         | PJSIP/2c70p24m-00000002 | CELGenUserEvent | XIVO_INCALL,54eb71f8-1f4b-4ae4-8730-638062fbe521                     | 1715000100.2 | 1715000100.2 | {"extra":"54eb71f8-1f4b-4ae4-8730-638062fbe521"}
+        WAZO_CALL_LOG_DESTINATION | 2024-05-07 20:01:00.700000+00 | 0012345678910 | 0012345678910 | s     | user        | PJSIP/2c70p24m-00000002 | CELGenUserEvent | WAZO_CALL_LOG_DESTINATION,type: user,uuid: cb79,name: Harry Potter   | 1715000100.2 | 1715000100.2 | {"extra":"type: user,uuid: cb79f29b-f69a-4b93-85c2-49dcce119a9f,name: Harry Potter"}
+        XIVO_USER_FWD             | 2024-05-07 20:01:02.000000+00 | 0012345678910 | 0012345678910 | s     | user        | PJSIP/2c70p24m-00000002 | CELGenUserEvent | XIVO_USER_FWD,NUM: 1006,CONTEXT: internal,NAME: Harry Potter         | 1715000100.2 | 1715000100.2 | {"extra":"NUM: 1006, CONTEXT: internal, NAME: Harry Potter"}
+        APP_START                 | 2024-05-07 20:01:02.500000+00 | 0012345678910 | 0012345678910 | s     | user        | PJSIP/2c70p24m-00000002 | VoiceMail       | 1006@default,u                                                      | 1715000100.2 | 1715000100.2 |
+        HANGUP                    | 2024-05-07 20:01:08.000000+00 | 0012345678910 | 0012345678910 | s     | user        | PJSIP/2c70p24m-00000002 |                 |                                                                      | 1715000100.2 | 1715000100.2 | {"hangupcause":16,"hangupsource":"","dialstatus":""}
+        CHAN_END                  | 2024-05-07 20:01:08.000000+00 | 0012345678910 | 0012345678910 | s     | user        | PJSIP/2c70p24m-00000002 |                 |                                                                      | 1715000100.2 | 1715000100.2 |
+        LINKEDID_END              | 2024-05-07 20:01:08.000000+00 | 0012345678910 | 0012345678910 | s     | user        | PJSIP/2c70p24m-00000002 |                 |                                                                      | 1715000100.2 | 1715000100.2 |
+        '''
+    )
+    def test_incoming_call_to_user_no_answer_then_voicemail(self, cels):
+        tenant_uuid = '54eb71f8-1f4b-4ae4-8730-638062fbe521'
+        user_uuid = 'cb79f29b-f69a-4b93-85c2-49dcce119a9f'
+        self.generator.confd = mock_confd_client(
+            users=[mock_user(uuid=user_uuid, tenant_uuid=tenant_uuid)],
+            voicemails=[
+                mock_voicemail(id=7, name='Harry VM', number='1006', context='default')
+            ],
+        )
+
+        call_logs = self.generator.call_logs_from_cel(cels)
+        assert len(call_logs) == 1
+
+        # Reaching the voicemail supersedes the authoritative user
+        # destination_details set by WAZO_CALL_LOG_DESTINATION (even though the
+        # call was forwarded), but destination_name is left as interpreted.
+        assert_that(
+            call_logs[0],
+            has_properties(
+                reached_voicemail=True,
+                date_answer=None,
+                destination_name='Harry Potter',
+                destination_details=contains_inanyorder(
+                    has_properties(
+                        destination_details_key='type',
+                        destination_details_value='voicemail',
+                    ),
+                    has_properties(
+                        destination_details_key='voicemail_id',
+                        destination_details_value='7',
+                    ),
+                    has_properties(
+                        destination_details_key='voicemail_name',
+                        destination_details_value='Harry VM',
+                    ),
+                ),
+            ),
+        )
+
+    @raw_cels(
+        '''
+        eventtype    | eventtime                     | cid_name      | cid_num       | exten | context     | channame                | appname         | appdata                                          | linkedid     | uniqueid     | extra
+        CHAN_START   | 2024-05-07 20:02:00.000000+00 | +12345678910  | +12345678910  | 1001  | from-extern | PJSIP/2c70p24m-00000003 |                 |                                                  | 1715000200.3 | 1715000200.3 |
+        XIVO_INCALL  | 2024-05-07 20:02:00.500000+00 | 0012345678910 | 0012345678910 | s     | did         | PJSIP/2c70p24m-00000003 | CELGenUserEvent | XIVO_INCALL,54eb71f8-1f4b-4ae4-8730-638062fbe521 | 1715000200.3 | 1715000200.3 | {"extra":"54eb71f8-1f4b-4ae4-8730-638062fbe521"}
+        APP_START    | 2024-05-07 20:02:01.000000+00 | 0012345678910 | 0012345678910 | s     | user        | PJSIP/2c70p24m-00000003 | VoiceMailMain   | 1001@default                                     | 1715000200.3 | 1715000200.3 |
+        HANGUP       | 2024-05-07 20:02:05.000000+00 | 0012345678910 | 0012345678910 | s     | user        | PJSIP/2c70p24m-00000003 |                 |                                                  | 1715000200.3 | 1715000200.3 | {"hangupcause":16,"hangupsource":"","dialstatus":""}
+        CHAN_END     | 2024-05-07 20:02:05.000000+00 | 0012345678910 | 0012345678910 | s     | user        | PJSIP/2c70p24m-00000003 |                 |                                                  | 1715000200.3 | 1715000200.3 |
+        LINKEDID_END | 2024-05-07 20:02:05.000000+00 | 0012345678910 | 0012345678910 | s     | user        | PJSIP/2c70p24m-00000003 |                 |                                                  | 1715000200.3 | 1715000200.3 |
+        '''
+    )
+    def test_voicemail_main_does_not_count_as_voicemail_redirection(self, cels):
+        # VoiceMailMain() is message retrieval, not a redirection to voicemail.
+        call_logs = self.generator.call_logs_from_cel(cels)
+        assert len(call_logs) == 1
+
+        assert_that(call_logs[0], has_properties(reached_voicemail=False))
 
     @raw_cels(
         '''

--- a/wazo_call_logd/tests/test_generator_scenarios.py
+++ b/wazo_call_logd/tests/test_generator_scenarios.py
@@ -12,6 +12,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock, Mock, create_autospec
 from uuid import uuid4
 
+import requests
 from hamcrest import assert_that, contains_inanyorder, has_properties
 from requests import HTTPError
 
@@ -387,6 +388,42 @@ class TestCallLogGenerationScenarios(TestCase):
         assert len(call_logs) == 1
 
         assert_that(call_logs[0], has_properties(reached_voicemail=False))
+
+    @raw_cels(
+        '''
+        eventtype    | eventtime                     | cid_name      | cid_num       | exten | context     | channame                | appname         | appdata                                          | linkedid     | uniqueid     | extra
+        CHAN_START   | 2024-05-07 20:03:00.000000+00 | +12345678910  | +12345678910  | 1004  | from-extern | PJSIP/2c70p24m-00000004 |                 |                                                  | 1715000300.4 | 1715000300.4 |
+        XIVO_INCALL  | 2024-05-07 20:03:00.500000+00 | 0012345678910 | 0012345678910 | s     | did         | PJSIP/2c70p24m-00000004 | CELGenUserEvent | XIVO_INCALL,54eb71f8-1f4b-4ae4-8730-638062fbe521 | 1715000300.4 | 1715000300.4 | {"extra":"54eb71f8-1f4b-4ae4-8730-638062fbe521"}
+        APP_START    | 2024-05-07 20:03:01.000000+00 | 0012345678910 | 0012345678910 | s     | user        | PJSIP/2c70p24m-00000004 | Voicemail       | 1004@default,u                                   | 1715000300.4 | 1715000300.4 |
+        HANGUP       | 2024-05-07 20:03:05.000000+00 | 0012345678910 | 0012345678910 | s     | user        | PJSIP/2c70p24m-00000004 |                 |                                                  | 1715000300.4 | 1715000300.4 | {"hangupcause":16,"hangupsource":"","dialstatus":""}
+        CHAN_END     | 2024-05-07 20:03:05.000000+00 | 0012345678910 | 0012345678910 | s     | user        | PJSIP/2c70p24m-00000004 |                 |                                                  | 1715000300.4 | 1715000300.4 |
+        LINKEDID_END | 2024-05-07 20:03:05.000000+00 | 0012345678910 | 0012345678910 | s     | user        | PJSIP/2c70p24m-00000004 |                 |                                                  | 1715000300.4 | 1715000300.4 |
+        '''
+    )
+    def test_voicemail_destination_resolution_survives_confd_failure(self, cels):
+        # A confd outage (connection error, not an HTTP error) during voicemail
+        # resolution must not drop the whole CDR: the CEL-derived voicemail state
+        # is kept, only the id/name enrichment is skipped.
+        self.generator.confd = mock_confd_client()
+        self.generator.confd.voicemails.list.side_effect = (
+            requests.exceptions.ConnectionError('confd unreachable')
+        )
+
+        call_logs = self.generator.call_logs_from_cel(cels)
+        assert len(call_logs) == 1
+
+        assert_that(
+            call_logs[0],
+            has_properties(
+                reached_voicemail=True,
+                destination_details=contains_inanyorder(
+                    has_properties(
+                        destination_details_key='type',
+                        destination_details_value='voicemail',
+                    ),
+                ),
+            ),
+        )
 
     @raw_cels(
         '''

--- a/wazo_call_logd/tests/test_generator_scenarios.py
+++ b/wazo_call_logd/tests/test_generator_scenarios.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock, Mock, create_autospec
 from uuid import uuid4
 
 import requests
-from hamcrest import assert_that, contains_inanyorder, has_properties
+from hamcrest import assert_that, contains_inanyorder, empty, has_properties
 from requests import HTTPError
 
 # from xivo_dao.alchemy.cel import CEL
@@ -401,9 +401,9 @@ class TestCallLogGenerationScenarios(TestCase):
         '''
     )
     def test_voicemail_destination_resolution_survives_confd_failure(self, cels):
-        # A confd outage (connection error, not an HTTP error) during voicemail
-        # resolution must not drop the whole CDR: the CEL-derived voicemail state
-        # is kept, only the id/name enrichment is skipped.
+        # A confd outage during voicemail resolution must not drop the whole
+        # CDR: the CEL-derived voicemail state is kept. With no interpreted
+        # destination to preserve, no identity-less voicemail entry is written.
         self.generator.confd = mock_confd_client()
         self.generator.confd.voicemails.list.side_effect = (
             requests.exceptions.ConnectionError('confd unreachable')
@@ -416,12 +416,7 @@ class TestCallLogGenerationScenarios(TestCase):
             call_logs[0],
             has_properties(
                 reached_voicemail=True,
-                destination_details=contains_inanyorder(
-                    has_properties(
-                        destination_details_key='type',
-                        destination_details_value='voicemail',
-                    ),
-                ),
+                destination_details=empty(),
             ),
         )
 

--- a/wazo_call_logd/tests/test_generator_scenarios.py
+++ b/wazo_call_logd/tests/test_generator_scenarios.py
@@ -373,6 +373,76 @@ class TestCallLogGenerationScenarios(TestCase):
 
     @raw_cels(
         '''
+        eventtype                 | eventtime                     | cid_name       | cid_num  | exten             | context                    | channame                                             | appname         | appdata                                              | linkedid     | uniqueid     | extra
+        CHAN_START                | 2026-07-20 19:45:15.345995+00 | 123            | eg8otwpk | 1234              | from-extern                | PJSIP/eg8otwpk-00000000                              |                 |                                                      | 1784576715.0 | 1784576715.0 |
+        XIVO_INCALL               | 2026-07-20 19:45:16.263404+00 | 123            | eg8otwpk | s                 | did                        | PJSIP/eg8otwpk-00000000                              | CELGenUserEvent | XIVO_INCALL,bebbeda2-ab4a-43af-a5e8-ab859ed2f40b     | 1784576715.0 | 1784576715.0 | {"extra":"bebbeda2-ab4a-43af-a5e8-ab859ed2f40b"}
+        WAZO_CALL_LOG_DESTINATION | 2026-07-20 19:45:16.386789+00 | 123            | eg8otwpk | s                 | user                       | PJSIP/eg8otwpk-00000000                              | CELGenUserEvent | WAZO_CALL_LOG_DESTINATION,type: user               | 1784576715.0 | 1784576715.0 | {"extra":"type: user,uuid: f6cb32d4-3364-424a-a7b2-d09c7df891ff,name: Paul Telephone"}
+        APP_START                 | 2026-07-20 19:45:16.427070+00 | 123            | eg8otwpk | s                 | user                       | PJSIP/eg8otwpk-00000000                              | Dial            | Local/G4rk8xzR@wazo_wait_for_registration&PJSIP     | 1784576715.0 | 1784576715.0 |
+        CHAN_START                | 2026-07-20 19:45:16.427468+00 |                |          | G4rk8xzR          | wazo_wait_for_registration | Local/G4rk8xzR@wazo_wait_for_registration-00000000;1 |                 |                                                      | 1784576715.0 | 1784576716.1 |
+        CHAN_START                | 2026-07-20 19:45:16.427494+00 |                |          | G4rk8xzR          | wazo_wait_for_registration | Local/G4rk8xzR@wazo_wait_for_registration-00000000;2 |                 |                                                      | 1784576715.0 | 1784576716.2 |
+        CHAN_START                | 2026-07-20 19:45:16.428090+00 | Paul Telephone | 1002     | s                 | internal                   | PJSIP/w6hpvj79-00000001                              |                 |                                                      | 1784576715.0 | 1784576716.3 |
+        HANGUP                    | 2026-07-20 19:45:18.543791+00 | Paul Telephone | 1002     | s                 | internal                   | PJSIP/w6hpvj79-00000001                              | AppDial         | (Outgoing Line)                                      | 1784576715.0 | 1784576716.3 | {"hangupcause":17,"hangupsource":"PJSIP/w6hpvj79-00000001","dialstatus":""}
+        CHAN_END                  | 2026-07-20 19:45:18.543791+00 | Paul Telephone | 1002     | s                 | internal                   | PJSIP/w6hpvj79-00000001                              | AppDial         | (Outgoing Line)                                      | 1784576715.0 | 1784576716.3 |
+        HANGUP                    | 2026-07-20 19:45:46.461119+00 | Paul Telephone | s        | s                 | wazo_wait_for_registration | Local/G4rk8xzR@wazo_wait_for_registration-00000000;1 | AppDial         | (Outgoing Line)                                      | 1784576715.0 | 1784576716.1 | {"hangupcause":0,"hangupsource":"","dialstatus":""}
+        CHAN_END                  | 2026-07-20 19:45:46.461119+00 | Paul Telephone | s        | s                 | wazo_wait_for_registration | Local/G4rk8xzR@wazo_wait_for_registration-00000000;1 | AppDial         | (Outgoing Line)                                      | 1784576715.0 | 1784576716.1 |
+        HANGUP                    | 2026-07-20 19:45:46.462248+00 | 123            | eg8otwpk | G4rk8xzR          | wazo_wait_for_registration | Local/G4rk8xzR@wazo_wait_for_registration-00000000;2 |                 |                                                      | 1784576715.0 | 1784576716.2 | {"hangupcause":0,"hangupsource":"","dialstatus":""}
+        CHAN_END                  | 2026-07-20 19:45:46.462248+00 | 123            | eg8otwpk | G4rk8xzR          | wazo_wait_for_registration | Local/G4rk8xzR@wazo_wait_for_registration-00000000;2 |                 |                                                      | 1784576715.0 | 1784576716.2 |
+        XIVO_USER_FWD             | 2026-07-20 19:45:46.462933+00 | 123            | eg8otwpk | forward_voicemail | user                       | PJSIP/eg8otwpk-00000000                              | CELGenUserEvent | XIVO_USER_FWD,NUM:1002                              | 1784576715.0 | 1784576715.0 | {"extra":"NUM:1002,CONTEXT:ucengine-key8477-internal,NAME:Paul Telephone"}
+        WAZO_USER_MISSED_CALL     | 2026-07-20 19:45:46.463095+00 | 123            | eg8otwpk | forward_voicemail | user                       | PJSIP/eg8otwpk-00000000                              | CELGenUserEvent | WAZO_USER_MISSED_CALL                              | 1784576715.0 | 1784576715.0 | {"extra":"wazo_tenant_uuid: bebbeda2-ab4a-43af-a5e8-ab859ed2f40b,source_user_uuid: ,destination_user_uuid: f6cb32d4-3364-424a-a7b2-d09c7df891ff,destination_exten: 1234,source_name: 123,destination_name: Paul%20Telephone"}
+        APP_START                 | 2026-07-20 19:45:46.468070+00 | 123            | eg8otwpk | voicemail         | user                       | PJSIP/eg8otwpk-00000000                              | VoiceMail       | 1002@ucengine-key8477-internal,u                    | 1784576715.0 | 1784576715.0 |
+        ANSWER                    | 2026-07-20 19:45:46.468124+00 | 123            | eg8otwpk | voicemail         | user                       | PJSIP/eg8otwpk-00000000                              | VoiceMail       | 1002@ucengine-key8477-internal,u                    | 1784576715.0 | 1784576715.0 |
+        HANGUP                    | 2026-07-20 19:46:20.000000+00 | 123            | eg8otwpk | voicemail         | user                       | PJSIP/eg8otwpk-00000000                              |                 |                                                      | 1784576715.0 | 1784576715.0 | {"hangupcause":16,"hangupsource":"","dialstatus":""}
+        CHAN_END                  | 2026-07-20 19:46:20.000000+00 | 123            | eg8otwpk | voicemail         | user                       | PJSIP/eg8otwpk-00000000                              |                 |                                                      | 1784576715.0 | 1784576715.0 |
+        LINKEDID_END              | 2026-07-20 19:46:20.000000+00 | 123            | eg8otwpk | voicemail         | user                       | PJSIP/eg8otwpk-00000000                              |                 |                                                      | 1784576715.0 | 1784576715.0 |
+        '''
+    )
+    def test_incoming_call_to_user_voicemail_via_local_registration(self, cels):
+        # Real production topology: an incall Dials the user through a
+        # Local/wazo_wait_for_registration pair; the line does not answer and
+        # the caller channel runs VoiceMail(). The VoiceMail APP_START is on the
+        # caller channel, so reached_voicemail must be set and the CDR surfaced
+        # as call_status=voicemail (unanswered).
+        tenant_uuid = 'bebbeda2-ab4a-43af-a5e8-ab859ed2f40b'
+        user_uuid = 'f6cb32d4-3364-424a-a7b2-d09c7df891ff'
+        self.generator.confd = mock_confd_client(
+            users=[mock_user(uuid=user_uuid, tenant_uuid=tenant_uuid)],
+            voicemails=[
+                mock_voicemail(
+                    id=12,
+                    name='Paul VM',
+                    number='1002',
+                    context='ucengine-key8477-internal',
+                )
+            ],
+        )
+
+        call_logs = self.generator.call_logs_from_cel(cels)
+        assert len(call_logs) == 1
+
+        assert_that(
+            call_logs[0],
+            has_properties(
+                reached_voicemail=True,
+                date_answer=None,
+                destination_details=contains_inanyorder(
+                    has_properties(
+                        destination_details_key='type',
+                        destination_details_value='voicemail',
+                    ),
+                    has_properties(
+                        destination_details_key='voicemail_id',
+                        destination_details_value='12',
+                    ),
+                    has_properties(
+                        destination_details_key='voicemail_name',
+                        destination_details_value='Paul VM',
+                    ),
+                ),
+            ),
+        )
+
+    @raw_cels(
+        '''
         eventtype    | eventtime                     | cid_name      | cid_num       | exten | context     | channame                | appname         | appdata                                          | linkedid     | uniqueid     | extra
         CHAN_START   | 2024-05-07 20:02:00.000000+00 | +12345678910  | +12345678910  | 1001  | from-extern | PJSIP/2c70p24m-00000003 |                 |                                                  | 1715000200.3 | 1715000200.3 |
         XIVO_INCALL  | 2024-05-07 20:02:00.500000+00 | 0012345678910 | 0012345678910 | s     | did         | PJSIP/2c70p24m-00000003 | CELGenUserEvent | XIVO_INCALL,54eb71f8-1f4b-4ae4-8730-638062fbe521 | 1715000200.3 | 1715000200.3 | {"extra":"54eb71f8-1f4b-4ae4-8730-638062fbe521"}


### PR DESCRIPTION
Detect when an unanswered call is redirected to a voicemail by recognizing
the native Asterisk VoiceMail application APP_START event in the CEL stream.
The CDR now reports call_status "voicemail" and a destination_details entry
of type "voicemail" (resolved to the voicemail id/name via confd), instead
of looking like a plain missed call. Adds the reached_voicemail column and
extends the destination_details key constraint via an Alembic migration.

ITEM-394

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CDR semantics and `destination_details` shape for voicemail calls (breaking for consumers of `destination_details.user_uuid`); relies on confd and correct CEL `apps=` config for detection.
> 
> **Overview**
> **CDRs now distinguish unanswered calls that reached voicemail** from plain missed calls, via a new `call_status` value `voicemail` and updated `destination_details`.
> 
> CEL processing detects Asterisk `VoiceMail` `APP_START` events (not `VoiceMailMain`) on caller, callee, and local-originate paths, storing `reached_voicemail` and mailbox number/context. For unanswered voicemail calls, `destination_details` is resolved through confd to `type: voicemail` with `voicemail_id` / `voicemail_name` instead of `user`; answered or confd-failure cases keep prior attribution.
> 
> **API and query behavior:** `GET /cdr` and user CDR endpoints accept `call_status=voicemail` and `unknown`; `unknown` is now enforced (previously ignored). Status precedence is **blocked → voicemail → answered → unknown**, mirrored in SQL filters, sort order, and `CDRSchema`. Schema migration adds `reached_voicemail` and extends destination key constraints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d28d1e5c2c47dccaf7687eaf063daeb8ae4df96a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->