### PR TITLE
ITEM-447-dynamic-thread-pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 26.08
+
+* New `rest_api.min_threads` option: threads kept ready at all times.
+  `max_threads` is now a ceiling the pool grows to under load, not a fixed
+  thread count.
+
 ## 26.07
 
 * Agent statistics now include a per-queue breakdown:

--- a/etc/wazo-call-logd/config.yml
+++ b/etc/wazo-call-logd/config.yml
@@ -30,10 +30,16 @@ rest_api:
     #Allow JSON preflight requests
     allow_headers: [Content-Type, Range, X-Auth-Token, Wazo-Tenant]
 
-  # Maximum of concurrent threads processing requests
+  # Minimum of concurrent threads processing requests. This many threads
+  # (and database connections) are kept ready at all times.
+  min_threads: 10
+
+  # Maximum of concurrent threads processing requests. The number of threads
+  # (and database connections) scales with demand between min_threads and
+  # max_threads.
   # See the performance documentation for more details
   # https://wazo-platform.org/uc-doc/system/performance/
-  max_threads: 10
+  max_threads: 100
 
 # wazo-auth (authentication daemon) connection settings.
 auth:

--- a/wazo_call_logd/config.py
+++ b/wazo_call_logd/config.py
@@ -63,7 +63,8 @@ DEFAULT_CONFIG = {
             'enabled': True,
             'allow_headers': ['Content-Type', 'Range', 'X-Auth-Token', 'Wazo-Tenant'],
         },
-        'max_threads': 10,
+        'min_threads': 10,
+        'max_threads': 100,
     },
     'auth': {
         'host': 'localhost',

--- a/wazo_call_logd/http_server.py
+++ b/wazo_call_logd/http_server.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -41,10 +41,11 @@ class HTTPServer:
         bind_addr = (self.config['listen'], self.config['port'])
 
         wsgi_app = ReverseProxied(ProxyFix(wsgi.WSGIPathInfoDispatcher({'/': app})))
-        self.server = wsgi.WSGIServer(
+        self.server = wsgi.DynamicWSGIServer(
             bind_addr=bind_addr,
             wsgi_app=wsgi_app,
-            numthreads=self.config['max_threads'],
+            numthreads=self.config['min_threads'],
+            max=self.config['max_threads'],
         )
         if self.config['certificate'] and self.config['private_key']:
             logger.warning(


### PR DESCRIPTION

Depends-on: https://github.com/wazo-platform/xivo-dao/pull/350
Depends-on: https://github.com/wazo-platform/xivo-lib-python/pull/187

Why: max_threads was a fixed thread count spawned at startup, wasting
idle threads and DB connections on quiet systems. The pool now grows
and shrinks between the new min_threads setting and max_threads, which
becomes a real ceiling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request concurrency and associated DB connection usage at runtime; default `max_threads` rises from 10 to 100 on upgrade unless overridden.
> 
> **Overview**
> Switches the REST API from a **fixed** thread pool to a **dynamic** one via `DynamicWSGIServer` (from `xivo-lib-python`). Startup keeps **`rest_api.min_threads`** workers ready; the pool **grows under load** up to **`rest_api.max_threads`**, which is now a ceiling instead of the count spawned at boot.
> 
> Defaults and docs are updated: **`min_threads: 10`**, **`max_threads: 100`** (previously only `max_threads: 10` as a fixed size) in `DEFAULT_CONFIG`, `etc/wazo-call-logd/config.yml`, and **CHANGELOG 26.08**. `http_server.py` passes `numthreads=min_threads` and `max=max_threads` when creating the server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db27b09dcd180531e9d8560411a692c671f8e3e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->