### PR TITLE
Pull CEL db image when MANAGE_DB_DIR is not set

### DIFF
--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -1,7 +1,11 @@
-MANAGE_DB_DIR ?= ../../xivo-manage-db/
-CEL_POSTGRES_DOCKER=$(MANAGE_DB_DIR)/contribs/docker/wazo-confd-db-test/Dockerfile
+ifeq ($(MANAGE_DB_DIR),)
+	CEL_DB_TARGET=cel-db-pull
+else
+	CEL_DB_TARGET=cel-db-build
+	CEL_POSTGRES_DOCKER=$(MANAGE_DB_DIR)/contribs/docker/wazo-confd-db-test/Dockerfile
+endif
 
-test-setup: egg-info call-logd purge-db db
+test-setup: egg-info call-logd purge-db db cel-db
 
 egg-info:
 	cd .. && python setup.py egg_info
@@ -16,10 +20,16 @@ call-logd:
 	docker build --no-cache -t wazoplatform/wazo-call-logd ..
 	docker build --no-cache -t wazo-call-logd-test -f docker/Dockerfile-call-logd-test ..
 
-cel-db:
-	docker build --no-cache -t wazoplatform/wazo-confd-db-test -f $(CEL_POSTGRES_DOCKER) $(MANAGE_DB_DIR)
+cel-db: $(CEL_DB_TARGET)
+
+cel-db-pull:
+	docker pull wazoplatform/wazo-confd-db-test
+	docker tag wazoplatform/wazo-confd-db-test:latest wazoplatform/wazo-confd-db-test:local
+
+cel-db-build:
+	docker build --pull --no-cache -t wazoplatform/wazo-confd-db-test:local -f $(CEL_POSTGRES_DOCKER) $(MANAGE_DB_DIR)
 
 db:
 	docker build -f ../contribs/docker/Dockerfile-db -t wazoplatform/wazo-call-logd-db ..
 
-.PHONY: test-setup test call-logd purge-db cel-db db
+.PHONY: test-setup test call-logd purge-db cel-db cel-db-pull cel-db-build db

--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - "9486"
 
   cel-postgres:
-    image: wazoplatform/wazo-confd-db-test
+    image: wazoplatform/wazo-confd-db-test:local
     ports:
       - "5432"
 

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,6 @@ pass_env =
     WAZO_TEST_NO_DOCKER_COMPOSE_PULL
 commands =
     make test-setup
-    make cel-db
     pytest -v {posargs}
 allowlist_externals =
     make


### PR DESCRIPTION
Tested with: https://jenkins.wazo.community/job/integration-tests-nolock/14393

CI now runs `tox -e integration` alone and has no local xivo-manage-db checkout to build the CEL db image from. Follow the wazo-confd pattern:

- pull the published `wazoplatform/wazo-confd-db-test` image by default, build from `MANAGE_DB_DIR` only when set, and tag both as `:local`
- `cel-db` is now part of `test-setup`, so tox no longer calls it separately

Side effect: local runs no longer build from `../../xivo-manage-db/` by default; set `MANAGE_DB_DIR` to test against local migrations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test/CI Docker wiring only; no runtime application or security-sensitive logic changes.
> 
> **Overview**
> **CI integration tests** no longer assume a local `xivo-manage-db` checkout. When `MANAGE_DB_DIR` is unset, `make cel-db` **pulls** `wazoplatform/wazo-confd-db-test` and tags it as `:local`; when set, it **builds** from that tree (wazo-confd-style split via `cel-db-pull` / `cel-db-build`).
> 
> `test-setup` now includes `cel-db`, so **tox** `integration` drops the extra `make cel-db` step. **docker-compose** points `cel-postgres` at `wazoplatform/wazo-confd-db-test:local` so pulled and built images match.
> 
> Local dev must set `MANAGE_DB_DIR` to exercise migrations from a nearby manage-db repo; default runs use the published image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae49a24ee33858fce5a2badf9242f6efe78bf098. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->