### PR TITLE
Use nginx for internal wazo-auth requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 26.09
+
+* Requests to wazo-auth now default to `localhost:80`, through nginx.
+
 ## 26.08
 
 * New `rest_api.min_threads` option: threads kept ready at all times.

--- a/etc/wazo-call-logd/config.yml
+++ b/etc/wazo-call-logd/config.yml
@@ -44,8 +44,7 @@ rest_api:
 # wazo-auth (authentication daemon) connection settings.
 auth:
   host: localhost
-  port: 9497
-  prefix: null
+  port: 80
   https: false
   key_file: /var/lib/wazo-auth-keys/wazo-call-logd-key.yml
 

--- a/integration_tests/assets/etc/wazo-call-logd/conf.d/50-default.yml
+++ b/integration_tests/assets/etc/wazo-call-logd/conf.d/50-default.yml
@@ -5,6 +5,8 @@ db_uri: postgresql://wazo-call-logd:Secr7t@postgres/wazo-call-logd
 cel_db_uri: postgresql://asterisk:proformatique@cel-postgres/asterisk
 auth:
   host: auth
+  port: 9497
+  prefix: null
   username: wazo-call-logd
   password: opensesame
   key_file: null

--- a/wazo_call_logd/config.py
+++ b/wazo_call_logd/config.py
@@ -68,8 +68,7 @@ DEFAULT_CONFIG = {
     },
     'auth': {
         'host': 'localhost',
-        'port': 9497,
-        'prefix': None,
+        'port': 80,
         'https': False,
         'key_file': '/var/lib/wazo-auth-keys/wazo-call-logd-key.yml',
         'master_tenant_uuid': None,


### PR DESCRIPTION
Points requests to wazo-auth at the nginx internal entry point
(`localhost:80`) instead of the wazo-auth process port, in both the Python
defaults and the shipped `config.yml` (the YAML is loaded on top of the Python
defaults, so both must change).

The `prefix` override is dropped rather than set: `wazo-auth-client` already
defaults to `/api/auth`.

Depends on:

* wazo-platform/wazo-nginx#23 — the internal entry point itself
* wazo-platform/wazo-auth#449 — the wazo-auth location served on it

Both must be deployed before this merges, otherwise internal auth calls 404.
Ticket: TASK-504

Notes:

* Integration test assets now pin `port: 9497` and `prefix: null` explicitly:
  their stacks have no nginx, and those values used to come from the defaults
  changed here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all internal auth traffic is reached at runtime and requires coordinated deployment with nginx/wazo-auth; mis-timed rollout breaks authentication for the service.
> 
> **Overview**
> **Default wazo-auth connectivity** now targets nginx on **`localhost:80`** instead of the wazo-auth daemon port **`9497`**, in both `DEFAULT_CONFIG` (`wazo_call_logd/config.py`) and the shipped `etc/wazo-call-logd/config.yml`.
> 
> The explicit **`auth.prefix`** default is removed from those defaults; **`wazo-auth-client`** is expected to keep using **`/api/auth`**. Integration test config **`50-default.yml`** explicitly sets **`port: 9497`** and **`prefix: null`** so stacks without nginx still talk to auth directly.
> 
> **CHANGELOG** documents this under **26.09**. Deploy **wazo-nginx** and **wazo-auth** dependency changes first, or internal auth calls can **404**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8f9a47a36ca6a9d22ccd1201080db128e43c0e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->